### PR TITLE
Operation property names

### DIFF
--- a/Classes/shared/SQKCoreDataOperation.m
+++ b/Classes/shared/SQKCoreDataOperation.m
@@ -68,11 +68,11 @@
 }
 
 - (BOOL)isExecuting {
-    return self.executing;
+    return self.sqk_executing;
 }
 
 - (BOOL)isFinished {
-    return self.finished;
+    return self.sqk_finished;
 }
 
 


### PR DESCRIPTION
Prefixed property names to prevent clash. (see #9)
