### PR TITLE
Updated Podfile to allow example project to build.

### DIFF
--- a/Examples/SQKCoreDataOperation Example/Podfile
+++ b/Examples/SQKCoreDataOperation Example/Podfile
@@ -1,12 +1,10 @@
 target "SQKCoreDataOperation Example" do
-	pod 'SQKDataKit/Core', :path => '../../SQKDataKit.podspec'
+	pod 'SQKDataKit/ContextManager', :path => '../../SQKDataKit.podspec'
 	pod 'SQKDataKit/CoreDataOperation', :path => '../../SQKDataKit.podspec'
 end
 
 target "SQKCoreDataOperation ExampleTests" do
-	pod 'SQKDataKit/Core', :path => '../../SQKDataKit.podspec'
+	pod 'SQKDataKit/ContextManager', :path => '../../SQKDataKit.podspec'
 	pod 'SQKDataKit/CoreDataOperation', :path => '../../SQKDataKit.podspec'
     pod 'AGAsyncTestHelper', '~> 1.0'
 end
-
-

--- a/Examples/SQKCoreDataOperation Example/Podfile.lock
+++ b/Examples/SQKCoreDataOperation Example/Podfile.lock
@@ -2,15 +2,15 @@ PODS:
   - AGAsyncTestHelper (1.0):
     - AGAsyncTestHelper/Core
   - AGAsyncTestHelper/Core (1.0)
-  - SQKDataKit/Core (0.5.0)
-  - SQKDataKit/CoreDataOperation (0.5.0):
-    - SQKDataKit/Core
+  - SQKDataKit/ContextManager (0.5.1)
+  - SQKDataKit/CoreDataOperation (0.5.1):
+    - SQKDataKit/ContextManager
     - SQKDataKit/ManagedObjectExtensions
-  - SQKDataKit/ManagedObjectExtensions (0.5.0)
+  - SQKDataKit/ManagedObjectExtensions (0.5.1)
 
 DEPENDENCIES:
   - AGAsyncTestHelper (~> 1.0)
-  - SQKDataKit/Core (from `../../SQKDataKit.podspec`)
+  - SQKDataKit/ContextManager (from `../../SQKDataKit.podspec`)
   - SQKDataKit/CoreDataOperation (from `../../SQKDataKit.podspec`)
 
 EXTERNAL SOURCES:
@@ -19,6 +19,6 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   AGAsyncTestHelper: fc9d44460933d8167ae431f466ab3a09a5121582
-  SQKDataKit: 5285810c2b14bfe04c1e4ec14df5e3f3731923d3
+  SQKDataKit: c628227e6f8c5b1d44e17323dcdb9dccf529c9c2
 
 COCOAPODS: 0.33.1


### PR DESCRIPTION
This was caused due to outdated sub spec names in the Podfile.

Names updated names of sub specs to allow the pod to install.
