### PR TITLE
Made managedObjectContext public so it can be set in the intiWithCoder.

### DIFF
--- a/Classes/ios/SQKFetchedTableViewController/SQKFetchedTableViewController.h
+++ b/Classes/ios/SQKFetchedTableViewController/SQKFetchedTableViewController.h
@@ -34,7 +34,7 @@ Data-backed table view. Must be used as a subclass.
 /**
  *  The managed object context backing the fetched results controller.
  */
-@property (nonatomic, strong, readonly) NSManagedObjectContext *managedObjectContext;
+@property (nonatomic, strong) NSManagedObjectContext *managedObjectContext;
 
 /**
  *  Returns YES if the user is actively searching, i.e. the search bar has begun editing. Returns NO

--- a/Classes/ios/SQKFetchedTableViewController/SQKFetchedTableViewController.m
+++ b/Classes/ios/SQKFetchedTableViewController/SQKFetchedTableViewController.m
@@ -23,7 +23,6 @@
 @interface SQKFetchedTableViewController ()
 @property (strong, nonatomic) NSFetchedResultsController *fetchedResultsController;
 @property (strong, nonatomic) NSFetchedResultsController *searchFetchedResultsController;
-@property (nonatomic, strong, readwrite) NSManagedObjectContext *managedObjectContext;
 @property (nonatomic, assign, readwrite) BOOL searchIsActive;
 @end
 


### PR DESCRIPTION
This is so the SQKFetchedTableViewController can be used with storyboards.
