### PR TITLE
Removed saveMainContex: nested, reference issue #15

### DIFF
--- a/Classes/shared/Core/SQKContextManager.h
+++ b/Classes/shared/Core/SQKContextManager.h
@@ -75,14 +75,4 @@
  */
 - (NSManagedObjectContext *)newPrivateContext;
 
-/**
- *  A convenience method to save the main managed object context.
- *
- *  @param error A pointer to an NSError object. You do not need to create an NSError object. The
- *save operation aborts after the first failure if you pass NULL.
- *
- *  @return YES if the save succeeds, otherwise NO.
- */
-- (BOOL)saveMainContext:(NSError **)error;
-
 @end

--- a/Classes/shared/Core/SQKContextManager.m
+++ b/Classes/shared/Core/SQKContextManager.m
@@ -127,16 +127,6 @@
     return context;
 }
 
-- (BOOL)saveMainContext:(NSError **)error
-{
-    if ([self.mainContext hasChanges])
-    {
-        [self.mainContext save:error];
-        return YES;
-    }
-    return NO;
-}
-
 - (void)dealloc
 {
     [[NSNotificationCenter defaultCenter] removeObserver:self

--- a/Project/SQKDataKitTests/SQKContextManagerTests.m
+++ b/Project/SQKDataKitTests/SQKContextManagerTests.m
@@ -160,34 +160,6 @@
 
 #pragma mark - Saving
 
-- (void)testSavesWhenThereAreChanges
-{
-    id contextWithChanges = [self mockMainContextWithStubbedHasChangesReturnValue:YES];
-    self.contextManager.mainContext = contextWithChanges;
-
-    [[contextWithChanges expect] save:(NSError * __autoreleasing *)[OCMArg anyPointer]];
-
-    NSError *saveError = nil;
-    BOOL didSave = [self.contextManager saveMainContext:&saveError];
-
-    XCTAssertTrue(didSave, @"");
-    [contextWithChanges verify];
-}
-
-- (void)testDoesNotSaveWhenThereAreNoChanges
-{
-    id contextWithoutChanges = [self mockMainContextWithStubbedHasChangesReturnValue:NO];
-    self.contextManager.mainContext = contextWithoutChanges;
-
-    [[contextWithoutChanges reject] save:(NSError * __autoreleasing *)[OCMArg anyPointer]];
-
-    NSError *saveError = nil;
-    BOOL didSave = [self.contextManager saveMainContext:&saveError];
-
-    XCTAssertFalse(didSave, @"");
-    [contextWithoutChanges verify];
-}
-
 - (void)testMergePropagatesChangesWhenMergingPrivateContextIsSaved
 {
     // Don't mock, testing IRL behavior.

--- a/Project/SQKDataKitTests/SQKManagedObjectControllerTests.m
+++ b/Project/SQKDataKitTests/SQKManagedObjectControllerTests.m
@@ -37,7 +37,7 @@
     self.commit = [Commit sqk_insertInContext:[self.contextManager mainContext]];
     self.commit.sha = @"abcd";
     self.commit.date = [NSDate date];
-    [self.contextManager saveMainContext:nil];
+    [[self.contextManager mainContext] save:NULL];
 
     NSFetchRequest *request = [Commit sqk_fetchRequest];
     request.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"date" ascending:NO]];
@@ -126,7 +126,7 @@
     commit2.sha = @"Insert 2";
     commit2.date = [NSDate date];
 
-    [self.contextManager saveMainContext:nil];
+    [[self.contextManager mainContext] save:NULL];
 
     AGWW_WAIT_WHILE(!blockUpdateDone, 2.0);
     XCTAssertEqual([[self.controller managedObjects] count], (NSUInteger)3, @"");
@@ -292,7 +292,7 @@
     commit2.sha = @"Insert 2";
     commit2.date = [NSDate date];
 
-    [self.contextManager saveMainContext:nil];
+    [[self.contextManager mainContext] save:NULL];
 
 
     XCTAssertEqual([[self.controller managedObjects] count], (NSUInteger)0, @"");
@@ -302,7 +302,7 @@
     Commit *commit3 = [Commit sqk_insertInContext:[self.contextManager mainContext]];
     commit3.sha = @"Insert 3";
     commit3.date = [NSDate date];
-    [self.contextManager saveMainContext:nil];
+    [[self.contextManager mainContext] save:NULL];
 
 
     XCTAssertEqual([[self.controller managedObjects] count], (NSUInteger)0, @"");


### PR DESCRIPTION
It doesn't really fit with the responsibilities for the context manager,
and it does't really do much other than call save: anyway.

Current the `testMergePropagatesChangesWhenMergingPrivateContextIsSaved` unit tests doesn't pass so don't merge.

Addresses [this issue](https://github.com/3squared/SQKDataKit/issues/15).
