### PR TITLE
SQKCoreDataOperation only saves and merges the private context it created.

### DIFF
--- a/Project/SQKDataKit.xcodeproj/project.pbxproj
+++ b/Project/SQKDataKit.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		A34BF42B184F6D0000F2E3B4 /* NSPersistentStoreCoordinatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A34BF42A184F6D0000F2E3B4 /* NSPersistentStoreCoordinatorTests.m */; };
 		A3C66D06185A20CE007AE9B5 /* NaiveImportOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = A3C66D05185A20CE007AE9B5 /* NaiveImportOperation.m */; };
 		A3C66D09185B2A19007AE9B5 /* GitDataImportOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = A3C66D08185B2A19007AE9B5 /* GitDataImportOperation.m */; };
+		A3CF4FD819B5C0A600691694 /* SQKCoreDataOperationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A3CF4FD719B5C0A600691694 /* SQKCoreDataOperationTests.m */; };
 		A3DC7C9B1868731100C45DB0 /* SQKJSONLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = A3DC7C9A1868731100C45DB0 /* SQKJSONLoader.m */; };
 		A3DC7CA018687E2E00C45DB0 /* data_1500.json in Resources */ = {isa = PBXBuildFile; fileRef = A3DC7C9F18687E2E00C45DB0 /* data_1500.json */; };
 		A3F70A8D1859D80C00C0A389 /* SQKCommitCell.m in Sources */ = {isa = PBXBuildFile; fileRef = A3F70A8C1859D80C00C0A389 /* SQKCommitCell.m */; };
@@ -102,6 +103,7 @@
 		A3C66D05185A20CE007AE9B5 /* NaiveImportOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = NaiveImportOperation.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		A3C66D07185B2A19007AE9B5 /* GitDataImportOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GitDataImportOperation.h; sourceTree = "<group>"; };
 		A3C66D08185B2A19007AE9B5 /* GitDataImportOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GitDataImportOperation.m; sourceTree = "<group>"; };
+		A3CF4FD719B5C0A600691694 /* SQKCoreDataOperationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SQKCoreDataOperationTests.m; sourceTree = "<group>"; };
 		A3DC7C991868731100C45DB0 /* SQKJSONLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SQKJSONLoader.h; sourceTree = "<group>"; };
 		A3DC7C9A1868731100C45DB0 /* SQKJSONLoader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SQKJSONLoader.m; sourceTree = "<group>"; };
 		A3DC7C9F18687E2E00C45DB0 /* data_1500.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = data_1500.json; sourceTree = "<group>"; };
@@ -279,6 +281,7 @@
 				A34BF42A184F6D0000F2E3B4 /* NSPersistentStoreCoordinatorTests.m */,
 				A328BAC01850921000267F2E /* NSManagedObjectTests.m */,
 				A30FAE8E1855DFBB008784C6 /* SQKJSONDataImportOperationTests.m */,
+				A3CF4FD719B5C0A600691694 /* SQKCoreDataOperationTests.m */,
 				A34BF3C3184F41D500F2E3B4 /* Supporting Files */,
 			);
 			path = SQKDataKitTests;
@@ -484,6 +487,7 @@
 			files = (
 				A328BAC11850921000267F2E /* NSManagedObjectTests.m in Sources */,
 				A34BF42B184F6D0000F2E3B4 /* NSPersistentStoreCoordinatorTests.m in Sources */,
+				A3CF4FD819B5C0A600691694 /* SQKCoreDataOperationTests.m in Sources */,
 				22BB628E1919256B00EEEFCE /* SQKManagedObjectControllerTests.m in Sources */,
 				A34BF3D4184F456B00F2E3B4 /* SQKContextManagerTests.m in Sources */,
 				A30FAE8F1855DFBB008784C6 /* SQKJSONDataImportOperationTests.m in Sources */,

--- a/Project/SQKDataKitTests/SQKCoreDataOperationTests.m
+++ b/Project/SQKDataKitTests/SQKCoreDataOperationTests.m
@@ -18,7 +18,7 @@
 
 @implementation SQKTestCoreDataOperation
 
-- (void)performWorkPrivateContext:(NSManagedObjectContext *)context {
+- (void)performWorkWithPrivateContext:(NSManagedObjectContext *)context {
     [self completeOperationBySavingContext:context];
 }
 
@@ -37,6 +37,7 @@
     NSManagedObjectModel *model= [NSManagedObjectModel mergedModelFromBundles:@[[NSBundle mainBundle]]];
     self.contextManager = [[SQKContextManager alloc] initWithStoreType:NSInMemoryStoreType
                                                     managedObjectModel:model
+                                        orderedManagedObjectModelNames:nil
                                                               storeURL:nil];
     self.mainContext = [self.contextManager mainContext];
     [self.mainContext reset];

--- a/Project/SQKDataKitTests/SQKCoreDataOperationTests.m
+++ b/Project/SQKDataKitTests/SQKCoreDataOperationTests.m
@@ -1,0 +1,66 @@
+//
+//  SQKCoreDataOperationTests.m
+//  SQKDataKit
+//
+//  Created by Luke Stringer on 02/09/2014.
+//  Copyright (c) 2014 3Squared. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "SQKContextManager.h"
+#import "SQKCoreDataOperation.h"
+#import <AGAsyncTestHelper/AGAsyncTestHelper.h>
+#import <OCMock/OCMock.h>
+
+@interface SQKTestCoreDataOperation : SQKCoreDataOperation
+
+@end
+
+@implementation SQKTestCoreDataOperation
+
+- (void)performWorkPrivateContext:(NSManagedObjectContext *)context {
+    [self completeOperationBySavingContext:context];
+}
+
+@end
+
+@interface SQKCoreDataOperationTests : XCTestCase
+@property (nonatomic, retain) SQKContextManager *contextManager;
+@property (nonatomic, retain) NSManagedObjectContext *mainContext;
+@property (nonatomic, retain) NSOperationQueue *queue;
+@end
+
+@implementation SQKCoreDataOperationTests
+
+- (void)setUp {
+    [super setUp];
+    NSManagedObjectModel *model= [NSManagedObjectModel mergedModelFromBundles:@[[NSBundle mainBundle]]];
+    self.contextManager = [[SQKContextManager alloc] initWithStoreType:NSInMemoryStoreType
+                                                    managedObjectModel:model
+                                                              storeURL:nil];
+    self.mainContext = [self.contextManager mainContext];
+    [self.mainContext reset];
+    
+    self.queue = [NSOperationQueue new];
+}
+
+- (void)testMergesIntoMainContextOnCompletion {
+    SQKTestCoreDataOperation *operation = [[SQKTestCoreDataOperation alloc] initWithContextManager:self.contextManager];
+    id mainContextPartialMock = [OCMockObject partialMockForObject:self.mainContext];
+    [[mainContextPartialMock expect] mergeChangesFromContextDidSaveNotification:[OCMArg any]];
+    
+    __block bool operationDone = NO;
+    [operation setCompletionBlock:^{
+        [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+            operationDone = YES;
+            [mainContextPartialMock verify];
+            [mainContextPartialMock stopMocking];
+        }];
+    }];
+    
+    [self.queue addOperation:operation];
+    
+    AGWW_WAIT_WHILE(!operationDone, 5.0);
+}
+
+@end


### PR DESCRIPTION
Addressing #6 

BUG: After adding this test the tests suite hangs during the 
[`[SQKManagedObjectControllerTests testInitialisingWithObjectAsync]`](https://github.com/3squared/SQKDataKit/blob/824a1a125b1ab5b4fb0f14570caa005cbf18dafd/Project/SQKDataKitTests/SQKManagedObjectControllerTests.m#L254) test on the [`[_mainContext mergeChangesFromContextDidSaveNotification:notification]`](https://github.com/3squared/SQKDataKit/blob/824a1a125b1ab5b4fb0f14570caa005cbf18dafd/Classes/shared/Core/SQKContextManager.m#L81) call in SQKContextManager.

See [travis build](https://travis-ci.org/3squared/SQKDataKit/builds/34169306#L475).