### PR TITLE
Publish-subscribe web service example

### DIFF
--- a/Examples/SQKCoreDataOperation Example/Podfile
+++ b/Examples/SQKCoreDataOperation Example/Podfile
@@ -8,5 +8,6 @@ end
 target "SQKCoreDataOperation ExampleTests" do
 	pod 'SQKDataKit/ContextManager', :path => '../../SQKDataKit.podspec'
 	pod 'SQKDataKit/CoreDataOperation', :path => '../../SQKDataKit.podspec'
-    pod 'AGAsyncTestHelper', '~> 1.0'
+  pod 'AGAsyncTestHelper', '~> 1.0'
+	pod 'OCMock', '~> 3.1'
 end

--- a/Examples/SQKCoreDataOperation Example/Podfile.lock
+++ b/Examples/SQKCoreDataOperation Example/Podfile.lock
@@ -2,6 +2,7 @@ PODS:
   - AGAsyncTestHelper (1.0):
     - AGAsyncTestHelper/Core
   - AGAsyncTestHelper/Core (1.0)
+  - OCMock (3.1.1)
   - SQKDataKit/ContextManager (0.5.2)
   - SQKDataKit/CoreDataOperation (0.5.2):
     - SQKDataKit/ContextManager
@@ -10,6 +11,7 @@ PODS:
 
 DEPENDENCIES:
   - AGAsyncTestHelper (~> 1.0)
+  - OCMock (~> 3.1)
   - SQKDataKit/ContextManager (from `../../SQKDataKit.podspec`)
   - SQKDataKit/CoreDataOperation (from `../../SQKDataKit.podspec`)
 
@@ -19,6 +21,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   AGAsyncTestHelper: fc9d44460933d8167ae431f466ab3a09a5121582
+  OCMock: f6cb8c162ab9d5620dddf411282c7b2c0ee78854
   SQKDataKit: a7b2f37587588927c7f683d96883d5594a54b50e
 
 COCOAPODS: 0.34.4

--- a/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation Example.xcodeproj/project.pbxproj
+++ b/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation Example.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		CBC1182619F6AC56006BAF51 /* CDOSynchronisationCoordinator.m in Sources */ = {isa = PBXBuildFile; fileRef = CBC1182519F6AC56006BAF51 /* CDOSynchronisationCoordinator.m */; };
 		CBC1182D19F6B8C5006BAF51 /* CDONotificationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = CBC1182C19F6B8C5006BAF51 /* CDONotificationManager.m */; };
 		CBC1183219F7AE8F006BAF51 /* CDONotificationManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CBC1183119F7AE8F006BAF51 /* CDONotificationManagerTests.m */; };
+		CBC1183419F7B5D1006BAF51 /* CDOSynchronisationCoordinatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CBC1183319F7B5D1006BAF51 /* CDOSynchronisationCoordinatorTests.m */; };
 		EA710AD8199E4B4D9173C99E /* libPods-SQKCoreDataOperation Example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D2283314E98B4621806285B1 /* libPods-SQKCoreDataOperation Example.a */; };
 /* End PBXBuildFile section */
 
@@ -112,6 +113,7 @@
 		CBC1182B19F6B8C5006BAF51 /* CDONotificationManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDONotificationManager.h; sourceTree = "<group>"; };
 		CBC1182C19F6B8C5006BAF51 /* CDONotificationManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDONotificationManager.m; sourceTree = "<group>"; };
 		CBC1183119F7AE8F006BAF51 /* CDONotificationManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDONotificationManagerTests.m; sourceTree = "<group>"; };
+		CBC1183319F7B5D1006BAF51 /* CDOSynchronisationCoordinatorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDOSynchronisationCoordinatorTests.m; sourceTree = "<group>"; };
 		D2283314E98B4621806285B1 /* libPods-SQKCoreDataOperation Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SQKCoreDataOperation Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DDF5D3C94F2249E2AFBB5E82 /* libPods-SQKCoreDataOperation ExampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SQKCoreDataOperation ExampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -286,6 +288,7 @@
 				A3F9AD6E1986885100058B79 /* CDOCommitImportOperationTests.m */,
 				A3F9AD731986982800058B79 /* CDOUserImportOperationTests.m */,
 				CBC1183119F7AE8F006BAF51 /* CDONotificationManagerTests.m */,
+				CBC1183319F7B5D1006BAF51 /* CDOSynchronisationCoordinatorTests.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -533,6 +536,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A3F9AD6F1986885100058B79 /* CDOCommitImportOperationTests.m in Sources */,
+				CBC1183419F7B5D1006BAF51 /* CDOSynchronisationCoordinatorTests.m in Sources */,
 				CBC1183219F7AE8F006BAF51 /* CDONotificationManagerTests.m in Sources */,
 				A3256C8719858EEF0063B939 /* CDOCommitImporterTests.m in Sources */,
 				A3256C92198599000063B939 /* CDOJSONFixtureLoader.m in Sources */,

--- a/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation Example.xcodeproj/project.pbxproj
+++ b/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation Example.xcodeproj/project.pbxproj
@@ -40,7 +40,8 @@
 		A3F9AD6F1986885100058B79 /* CDOCommitImportOperationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A3F9AD6E1986885100058B79 /* CDOCommitImportOperationTests.m */; };
 		A3F9AD72198697E200058B79 /* CDOUserImportOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = A3F9AD71198697E200058B79 /* CDOUserImportOperation.m */; };
 		A3F9AD741986982800058B79 /* CDOUserImportOperationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A3F9AD731986982800058B79 /* CDOUserImportOperationTests.m */; };
-		CBC1182619F6AC56006BAF51 /* CDODataSynchroniser.m in Sources */ = {isa = PBXBuildFile; fileRef = CBC1182519F6AC56006BAF51 /* CDODataSynchroniser.m */; };
+		CBC1182619F6AC56006BAF51 /* CDOSynchronisationCoordinator.m in Sources */ = {isa = PBXBuildFile; fileRef = CBC1182519F6AC56006BAF51 /* CDOSynchronisationCoordinator.m */; };
+		CBC1182D19F6B8C5006BAF51 /* CDONotificationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = CBC1182C19F6B8C5006BAF51 /* CDONotificationManager.m */; };
 		EA710AD8199E4B4D9173C99E /* libPods-SQKCoreDataOperation Example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D2283314E98B4621806285B1 /* libPods-SQKCoreDataOperation Example.a */; };
 /* End PBXBuildFile section */
 
@@ -105,8 +106,10 @@
 		A3F9AD71198697E200058B79 /* CDOUserImportOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDOUserImportOperation.m; sourceTree = "<group>"; };
 		A3F9AD731986982800058B79 /* CDOUserImportOperationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDOUserImportOperationTests.m; sourceTree = "<group>"; };
 		CBC1182119F6A503006BAF51 /* GithubToken.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = GithubToken.plist; path = "SQKCoreDataOperation Example/Web Client/GithubToken.plist"; sourceTree = SOURCE_ROOT; };
-		CBC1182419F6AC56006BAF51 /* CDODataSynchroniser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDODataSynchroniser.h; sourceTree = "<group>"; };
-		CBC1182519F6AC56006BAF51 /* CDODataSynchroniser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDODataSynchroniser.m; sourceTree = "<group>"; };
+		CBC1182419F6AC56006BAF51 /* CDOSynchronisationCoordinator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDOSynchronisationCoordinator.h; sourceTree = "<group>"; };
+		CBC1182519F6AC56006BAF51 /* CDOSynchronisationCoordinator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDOSynchronisationCoordinator.m; sourceTree = "<group>"; };
+		CBC1182B19F6B8C5006BAF51 /* CDONotificationManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDONotificationManager.h; sourceTree = "<group>"; };
+		CBC1182C19F6B8C5006BAF51 /* CDONotificationManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDONotificationManager.m; sourceTree = "<group>"; };
 		D2283314E98B4621806285B1 /* libPods-SQKCoreDataOperation Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SQKCoreDataOperation Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DDF5D3C94F2249E2AFBB5E82 /* libPods-SQKCoreDataOperation ExampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SQKCoreDataOperation ExampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -329,8 +332,10 @@
 		CBC1182319F6AC56006BAF51 /* Data Synchronisation */ = {
 			isa = PBXGroup;
 			children = (
-				CBC1182419F6AC56006BAF51 /* CDODataSynchroniser.h */,
-				CBC1182519F6AC56006BAF51 /* CDODataSynchroniser.m */,
+				CBC1182419F6AC56006BAF51 /* CDOSynchronisationCoordinator.h */,
+				CBC1182519F6AC56006BAF51 /* CDOSynchronisationCoordinator.m */,
+				CBC1182B19F6B8C5006BAF51 /* CDONotificationManager.h */,
+				CBC1182C19F6B8C5006BAF51 /* CDONotificationManager.m */,
 			);
 			path = "Data Synchronisation";
 			sourceTree = "<group>";
@@ -504,10 +509,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CBC1182D19F6B8C5006BAF51 /* CDONotificationManager.m in Sources */,
 				A3256C811985676D0063B939 /* User.m in Sources */,
 				A3256C4B19852D630063B939 /* SQKCoreDataOperation_Example.xcdatamodeld in Sources */,
 				A3256C72198535C20063B939 /* CDOGithubAPIClient.m in Sources */,
-				CBC1182619F6AC56006BAF51 /* CDODataSynchroniser.m in Sources */,
+				CBC1182619F6AC56006BAF51 /* CDOSynchronisationCoordinator.m in Sources */,
 				A3256C7E1985676C0063B939 /* Commit.m in Sources */,
 				A3256C8A198591870063B939 /* CDOCommitImporter.m in Sources */,
 				A3F9AD65198660EA00058B79 /* CDODataImporter.m in Sources */,

--- a/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation Example.xcodeproj/project.pbxproj
+++ b/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation Example.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		A3F9AD741986982800058B79 /* CDOUserImportOperationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A3F9AD731986982800058B79 /* CDOUserImportOperationTests.m */; };
 		CBC1182619F6AC56006BAF51 /* CDOSynchronisationCoordinator.m in Sources */ = {isa = PBXBuildFile; fileRef = CBC1182519F6AC56006BAF51 /* CDOSynchronisationCoordinator.m */; };
 		CBC1182D19F6B8C5006BAF51 /* CDONotificationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = CBC1182C19F6B8C5006BAF51 /* CDONotificationManager.m */; };
+		CBC1183219F7AE8F006BAF51 /* CDONotificationManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CBC1183119F7AE8F006BAF51 /* CDONotificationManagerTests.m */; };
 		EA710AD8199E4B4D9173C99E /* libPods-SQKCoreDataOperation Example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D2283314E98B4621806285B1 /* libPods-SQKCoreDataOperation Example.a */; };
 /* End PBXBuildFile section */
 
@@ -110,6 +111,7 @@
 		CBC1182519F6AC56006BAF51 /* CDOSynchronisationCoordinator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDOSynchronisationCoordinator.m; sourceTree = "<group>"; };
 		CBC1182B19F6B8C5006BAF51 /* CDONotificationManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDONotificationManager.h; sourceTree = "<group>"; };
 		CBC1182C19F6B8C5006BAF51 /* CDONotificationManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDONotificationManager.m; sourceTree = "<group>"; };
+		CBC1183119F7AE8F006BAF51 /* CDONotificationManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDONotificationManagerTests.m; sourceTree = "<group>"; };
 		D2283314E98B4621806285B1 /* libPods-SQKCoreDataOperation Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SQKCoreDataOperation Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DDF5D3C94F2249E2AFBB5E82 /* libPods-SQKCoreDataOperation ExampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SQKCoreDataOperation ExampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -283,6 +285,7 @@
 				A3F9AD68198662E200058B79 /* CDOUserImporterTests.m */,
 				A3F9AD6E1986885100058B79 /* CDOCommitImportOperationTests.m */,
 				A3F9AD731986982800058B79 /* CDOUserImportOperationTests.m */,
+				CBC1183119F7AE8F006BAF51 /* CDONotificationManagerTests.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -530,6 +533,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A3F9AD6F1986885100058B79 /* CDOCommitImportOperationTests.m in Sources */,
+				CBC1183219F7AE8F006BAF51 /* CDONotificationManagerTests.m in Sources */,
 				A3256C8719858EEF0063B939 /* CDOCommitImporterTests.m in Sources */,
 				A3256C92198599000063B939 /* CDOJSONFixtureLoader.m in Sources */,
 				A3F9AD741986982800058B79 /* CDOUserImportOperationTests.m in Sources */,

--- a/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation Example/CDOAppDelegate.m
+++ b/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation Example/CDOAppDelegate.m
@@ -26,10 +26,6 @@
 	// Set your Github API access token for the CDOGithubAPIClient
 	// See: https://github.com/settings/applications#personal-access-tokens
 	// I'm loading mine from a .plist (ignored in the git repo)
-	NSString *path = [[NSBundle mainBundle] pathForResource:@"GithubToken" ofType:@"plist"];
-	NSDictionary *plistDict = [NSDictionary dictionaryWithContentsOfFile:path];
-	NSString *accessToken = plistDict[@"token"];
-	[CDOGithubAPIClient sharedInstance].accessToken = accessToken;
 
 	NSManagedObjectModel *model = [NSManagedObjectModel mergedModelFromBundles:nil];
 	self.contextManager = [[SQKContextManager alloc] initWithStoreType:NSSQLiteStoreType
@@ -40,7 +36,12 @@
     [CDONotificationManager addObserverForSynchronisationRequestNotification:self selector:@selector(didRequestSynchronisation:)];
     [CDONotificationManager addObserverForSynchronisationResponseNotification:self selector:@selector(didCompleteSynchronisation:)];
 
-	self.syncCoordinator = [[CDOSynchronisationCoordinator alloc] initWithContextManager:self.contextManager];
+    NSString *path = [[NSBundle mainBundle] pathForResource:@"GithubToken" ofType:@"plist"];
+    NSDictionary *plistDict = [NSDictionary dictionaryWithContentsOfFile:path];
+    NSString *accessToken = plistDict[@"token"];
+
+    CDOGithubAPIClient *APIClient = [[CDOGithubAPIClient alloc] initWithAccessToken:accessToken];
+    self.syncCoordinator = [[CDOSynchronisationCoordinator alloc] initWithContextManager:self.contextManager APIClient:APIClient];
 
     [CDOSynchronisationCoordinator synchronise];
     

--- a/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation Example/CDOAppDelegate.m
+++ b/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation Example/CDOAppDelegate.m
@@ -8,12 +8,13 @@
 
 #import "CDOAppDelegate.h"
 #import "CDOGithubAPIClient.h"
-#import "CDODataSynchroniser.h"
+#import "CDOSynchronisationCoordinator.h"
 #import "SQKContextManager.h"
 #import "CDORunningTestsHelper.h"
+#import "CDONotificationManager.h"
 
 @interface CDOAppDelegate ()
-@property (nonatomic, strong) CDODataSynchroniser *dataSynchroniser;
+@property (nonatomic, strong) CDOSynchronisationCoordinator *syncCoordinator;
 @property (nonatomic, strong) SQKContextManager *contextManager;
 @end
 
@@ -35,10 +36,25 @@
 	                                                managedObjectModel:model
 	                                                          storeURL:nil];
 
-	self.dataSynchroniser = [[CDODataSynchroniser alloc] initWithContextManager:self.contextManager];
-	[self.dataSynchroniser synchronise];
+    
+    [CDONotificationManager addObserverForSynchronisationRequestNotification:self selector:@selector(didRequestSynchronisation:)];
+    [CDONotificationManager addObserverForSynchronisationResponseNotification:self selector:@selector(didCompleteSynchronisation:)];
 
+	self.syncCoordinator = [[CDOSynchronisationCoordinator alloc] initWithContextManager:self.contextManager];
+
+    [CDOSynchronisationCoordinator synchronise];
+    
 	return YES;
+}
+
+- (void) didRequestSynchronisation:(NSNotification*)notification
+{
+    NSLog(@"didRequestSynchronisation: %@", notification);
+}
+
+- (void) didCompleteSynchronisation:(NSNotification*)notification
+{
+    NSLog(@"didCompleteSynchronisation: %@", notification);
 }
 
 @end

--- a/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation Example/Data Synchronisation/CDONotificationManager.h
+++ b/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation Example/Data Synchronisation/CDONotificationManager.h
@@ -1,0 +1,19 @@
+//
+//  CDONotificationManager.h
+//  SQKCoreDataOperation Example
+//
+//  Created by Sam Oakley on 21/10/2014.
+//  Copyright (c) 2014 3Squared Ltd. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface CDONotificationManager : NSObject
+
++ (void) addObserverForSynchronisationRequestNotification:(id)observer selector:(SEL)aSelector;
++ (void) removeObserverForSynchronisationRequestNotification:(id)observer;
+
++ (void) addObserverForSynchronisationResponseNotification:(id)observer selector:(SEL)aSelector;
++ (void) removeObserverForSynchronisationResponseNotification:(id)observer;
+
+@end

--- a/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation Example/Data Synchronisation/CDONotificationManager.m
+++ b/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation Example/Data Synchronisation/CDONotificationManager.m
@@ -1,0 +1,34 @@
+//
+//  CDONotificationManager.m
+//  SQKCoreDataOperation Example
+//
+//  Created by Sam Oakley on 21/10/2014.
+//  Copyright (c) 2014 3Squared Ltd. All rights reserved.
+//
+
+#import "CDONotificationManager.h"
+#import "CDOSynchronisationCoordinator.h"
+
+@implementation CDONotificationManager
+
++ (void) addObserverForSynchronisationRequestNotification:(id)observer selector:(SEL)aSelector
+{
+    [[NSNotificationCenter defaultCenter] addObserver:observer selector:aSelector name:CDOSynchronisationRequestNotification object:nil];
+}
+
++ (void) removeObserverForSynchronisationRequestNotification:(id)observer
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:observer name:CDOSynchronisationRequestNotification object:nil];
+}
+
++ (void) addObserverForSynchronisationResponseNotification:(id)observer selector:(SEL)aSelector
+{
+    [[NSNotificationCenter defaultCenter] addObserver:observer selector:aSelector name:CDOSynchronisationResponseNotification object:nil];
+}
+
++ (void) removeObserverForSynchronisationResponseNotification:(id)observer
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:observer name:CDOSynchronisationResponseNotification object:nil];
+}
+
+@end

--- a/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation Example/Data Synchronisation/CDOSynchronisationCoordinator.h
+++ b/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation Example/Data Synchronisation/CDOSynchronisationCoordinator.h
@@ -11,12 +11,12 @@
 extern NSString * const CDOSynchronisationRequestNotification;
 extern NSString * const CDOSynchronisationResponseNotification;
 
-@class SQKContextManager;
+@class SQKContextManager, CDOGithubAPIClient;
 @interface CDOSynchronisationCoordinator : NSObject
 
 @property (nonatomic, strong, readonly) SQKContextManager *contextManager;
 
-- (instancetype)initWithContextManager:(SQKContextManager *)contextManager;
+- (instancetype)initWithContextManager:(SQKContextManager *)contextManager APIClient:(CDOGithubAPIClient *)APIClient;
 
 + (void)synchronise;
 

--- a/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation Example/Data Synchronisation/CDOSynchronisationCoordinator.h
+++ b/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation Example/Data Synchronisation/CDOSynchronisationCoordinator.h
@@ -8,18 +8,16 @@
 
 #import <Foundation/Foundation.h>
 
+extern NSString * const CDOSynchronisationRequestNotification;
+extern NSString * const CDOSynchronisationResponseNotification;
+
 @class SQKContextManager;
-@interface CDODataSynchroniser : NSObject
+@interface CDOSynchronisationCoordinator : NSObject
 
 @property (nonatomic, strong, readonly) SQKContextManager *contextManager;
-@property (nonatomic, assign, readonly) BOOL isSynchronising;
 
 - (instancetype)initWithContextManager:(SQKContextManager *)contextManager;
 
-/**
- *  Synchronises now, or if currently synchronising queues up another synchronise to occur after the current synchronise finishes.
- */
-- (void)synchronise;
-
++ (void)synchronise;
 
 @end

--- a/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation Example/Data Synchronisation/CDOSynchronisationCoordinator.m
+++ b/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation Example/Data Synchronisation/CDOSynchronisationCoordinator.m
@@ -84,7 +84,7 @@ NSString * const CDOSynchronisationResponseNotification = @"CDOSynchronisationRe
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {
 	SQKCoreDataOperation *nextOperation = [[self.operationQueue operations] firstObject];
-	for (SQKCoreDataOperation *dependentOperation in[nextOperation dependencies]) {
+	for (SQKCoreDataOperation *dependentOperation in [nextOperation dependencies]) {
 		/**
 		 *  Next operation to be executed should be cancelled if any of it's dependencies have
 		 *  errored or were also cancelled. By cancelling the next operation we will also

--- a/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation Example/Operations/CDOCommitImportOperation.h
+++ b/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation Example/Operations/CDOCommitImportOperation.h
@@ -8,6 +8,9 @@
 
 #import "SQKCoreDataOperation.h"
 
+@class CDOGithubAPIClient;
 @interface CDOCommitImportOperation : SQKCoreDataOperation
+
+- (instancetype)initWithContextManager:(SQKContextManager *)contextManager APIClient:(CDOGithubAPIClient *)APIClient;
 
 @end

--- a/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation Example/Operations/CDOCommitImportOperation.m
+++ b/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation Example/Operations/CDOCommitImportOperation.m
@@ -12,15 +12,25 @@
 
 @interface CDOCommitImportOperation ()
 @property (nonatomic, strong) NSError *operationError;
+@property (nonatomic, strong) CDOGithubAPIClient *APIClient;
 @end
 
 @implementation CDOCommitImportOperation
+
+- (instancetype)initWithContextManager:(SQKContextManager *)contextManager APIClient:(CDOGithubAPIClient *)APIClient
+{
+    self = [super initWithContextManager:contextManager];
+    if (self) {
+        self.APIClient = APIClient;
+    }
+    return self;
+}
 
 - (void)performWorkWithPrivateContext:(NSManagedObjectContext *)context {
 	NSLog(@"Executing %@", NSStringFromClass([self class]));
 
 	NSError *error = nil;
-	NSArray *commits = [[CDOGithubAPIClient sharedInstance] getCommitsForRepo:@"sqkdatakit" error:&error];
+	NSArray *commits = [self.APIClient getCommitsForRepo:@"sqkdatakit" error:&error];
 	if (error) {
 		self.operationError = error;
 		NSLog(@"%@", error);

--- a/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation Example/Operations/CDOUserImportOperation.h
+++ b/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation Example/Operations/CDOUserImportOperation.h
@@ -8,6 +8,9 @@
 
 #import "SQKCoreDataOperation.h"
 
+@class CDOGithubAPIClient;
 @interface CDOUserImportOperation : SQKCoreDataOperation
+
+- (instancetype)initWithContextManager:(SQKContextManager *)contextManager APIClient:(CDOGithubAPIClient *)APIClient;
 
 @end

--- a/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation Example/Operations/CDOUserImportOperation.m
+++ b/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation Example/Operations/CDOUserImportOperation.m
@@ -14,9 +14,20 @@
 
 @interface CDOUserImportOperation ()
 @property (nonatomic, strong) NSError *operationError;
+@property (nonatomic, strong) CDOGithubAPIClient *APIClient;
 @end
 
 @implementation CDOUserImportOperation
+
+
+- (instancetype)initWithContextManager:(SQKContextManager *)contextManager APIClient:(CDOGithubAPIClient *)APIClient
+{
+    self = [super initWithContextManager:contextManager];
+    if (self) {
+        self.APIClient = APIClient;
+    }
+    return self;
+}
 
 - (void)performWorkWithPrivateContext:(NSManagedObjectContext *)context {
 	NSLog(@"Executing %@", NSStringFromClass([self class]));
@@ -28,7 +39,7 @@
 
 	if (users.count > 0) {
 		for (User *user in users) {
-			id JSON = [[CDOGithubAPIClient sharedInstance] getUser:user.username error:NULL];
+			id JSON = [self.APIClient getUser:user.username error:NULL];
 			[usersJSON addObject:JSON];
 		}
 		CDOUserImporter *importer = [[CDOUserImporter alloc] initWithManagedObjectContext:context];

--- a/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation Example/Web Client/CDOGithubAPIClient.h
+++ b/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation Example/Web Client/CDOGithubAPIClient.h
@@ -10,9 +10,7 @@
 
 @interface CDOGithubAPIClient : NSObject
 
-@property (nonatomic, strong) NSString *accessToken;
-
-+ (CDOGithubAPIClient *)sharedInstance;
+- (instancetype)initWithAccessToken:(NSString *)accessToken;
 
 - (id)getCommitsForRepo:(NSString *)repoName error:(NSError **)error;
 - (id)getUser:(NSString *)username error:(NSError **)error;

--- a/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation Example/Web Client/CDOGithubAPIClient.m
+++ b/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation Example/Web Client/CDOGithubAPIClient.m
@@ -11,20 +11,22 @@
 static NSString *const CDOHBaseURL = @"https://api.github.com";
 static NSString *const CDOGithubAPIClientErrorDomain = @"com.3squared.CDOGithubAPIClientErrorDomain";
 
+@interface CDOGithubAPIClient ()
+@property (nonatomic, strong) NSString *accessToken;
+@end
+
 @implementation CDOGithubAPIClient
 
-#pragma mark - Singleton setup
-+ (CDOGithubAPIClient *)sharedInstance {
-	static CDOGithubAPIClient *sharedSingleton;
-	static dispatch_once_t onceToken;
-	dispatch_once(&onceToken, ^{
-	    sharedSingleton = [[CDOGithubAPIClient alloc] init];
-	});
-
-	return sharedSingleton;
-}
-
 #pragma mark - Public
+
+- (instancetype)initWithAccessToken:(NSString *)accessToken
+{
+    self = [super init];
+    if (self) {
+        self.accessToken = accessToken;
+    }
+    return self;
+}
 
 - (id)getCommitsForRepo:(NSString *)repoName error:(NSError **)error {
 	NSString *endpoint = [NSString stringWithFormat:@"repos/3squared/%@/commits", repoName];

--- a/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation ExampleTests/Tests/CDOCommitImportOperationTests.m
+++ b/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation ExampleTests/Tests/CDOCommitImportOperationTests.m
@@ -32,13 +32,13 @@
 	NSString *path = [[NSBundle mainBundle] pathForResource:@"GithubToken" ofType:@"plist"];
 	NSDictionary *plistDict = [NSDictionary dictionaryWithContentsOfFile:path];
 	NSString *accessToken = plistDict[@"token"];
-	[CDOGithubAPIClient sharedInstance].accessToken = accessToken;
+    CDOGithubAPIClient *APIClient = [[CDOGithubAPIClient alloc] initWithAccessToken:accessToken];
 
 	NSManagedObjectModel *model = [NSManagedObjectModel mergedModelFromBundles:nil];
 	self.contextManager = [[SQKContextManager alloc] initWithStoreType:NSInMemoryStoreType
 	                                                managedObjectModel:model
 	                                                          storeURL:nil];
-	self.operation = [[CDOCommitImportOperation alloc] initWithContextManager:self.contextManager];
+	self.operation = [[CDOCommitImportOperation alloc] initWithContextManager:self.contextManager APIClient:APIClient];
 	self.queue = [NSOperationQueue new];
 }
 

--- a/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation ExampleTests/Tests/CDONotificationManagerTests.m
+++ b/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation ExampleTests/Tests/CDONotificationManagerTests.m
@@ -1,0 +1,45 @@
+//
+//  CDONotificationManagerTests.m
+//  SQKCoreDataOperation Example
+//
+//  Created by Sam Oakley on 22/10/2014.
+//  Copyright (c) 2014 3Squared Ltd. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+#import "CDOSynchronisationCoordinator.h"
+#import "CDONotificationManager.h"
+
+@interface CDONotificationManagerTests : XCTestCase
+@property (strong, nonatomic) XCTestExpectation *notificationExpectation;
+@end
+
+@implementation CDONotificationManagerTests
+
+-(void)tearDown
+{
+    self.notificationExpectation = nil;
+}
+
+- (void)testSynchronisationRequestObserver {
+    self.notificationExpectation = [self expectationWithDescription:@"Request notification observed"];
+    [CDONotificationManager addObserverForSynchronisationRequestNotification:self selector:@selector(notificationSelector:)];
+    [[NSNotificationCenter defaultCenter] postNotificationName:CDOSynchronisationRequestNotification object:nil];
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+- (void)testSynchronisationResponseObserver {
+    self.notificationExpectation = [self expectationWithDescription:@"Response notification observed"];
+    [CDONotificationManager addObserverForSynchronisationResponseNotification:self selector:@selector(notificationSelector:)];
+    [[NSNotificationCenter defaultCenter] postNotificationName:CDOSynchronisationResponseNotification object:nil];
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+- (void) notificationSelector:(NSNotification*)notification {
+    [self.notificationExpectation fulfill];
+}
+
+@end

--- a/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation ExampleTests/Tests/CDOSynchronisationCoordinatorTests.m
+++ b/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation ExampleTests/Tests/CDOSynchronisationCoordinatorTests.m
@@ -1,0 +1,61 @@
+//
+//  CDOSynchronisationCoordinator.m
+//  SQKCoreDataOperation Example
+//
+//  Created by Sam Oakley on 22/10/2014.
+//  Copyright (c) 2014 3Squared Ltd. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
+#import "CDOGithubAPIClient.h"
+#import "CDOSynchronisationCoordinator.h"
+#import "CDOJSONFixtureLoader.h"
+#import <SQKDataKit/SQKContextManager.h>
+
+@interface CDOSynchronisationCoordinatorTests : XCTestCase
+@property (strong, nonatomic) CDOSynchronisationCoordinator *syncCoordinator;
+@end
+
+@implementation CDOSynchronisationCoordinatorTests
+
+- (void)setUp {
+    [super setUp];
+    
+    NSManagedObjectModel *model = [NSManagedObjectModel mergedModelFromBundles:nil];
+    SQKContextManager *contextManager = [[SQKContextManager alloc] initWithStoreType:NSInMemoryStoreType
+                                                                  managedObjectModel:model
+                                                                            storeURL:nil];
+
+
+    CDOGithubAPIClient *APIClientMock = OCMClassMock([CDOGithubAPIClient class]);
+    
+    NSArray *usersJSON = [CDOJSONFixtureLoader loadJSONFileNamed:@"users"];
+    NSArray *commitsJSON = [CDOJSONFixtureLoader loadJSONFileNamed:@"commits"];
+
+    OCMStub([APIClientMock getCommitsForRepo:[OCMArg any] error:[OCMArg anyObjectRef]]).andReturn(commitsJSON);
+    OCMStub([APIClientMock getUser:[OCMArg any] error:[OCMArg anyObjectRef]]).andReturn(usersJSON[0]);
+
+    self.syncCoordinator = [[CDOSynchronisationCoordinator alloc] initWithContextManager:contextManager
+                                                                                                         APIClient:APIClientMock];
+}
+
+
+- (void)tearDown {
+    [super tearDown];
+    self.syncCoordinator = nil;
+}
+
+- (void)testSynchronisationNotifications
+{
+    [self expectationForNotification:CDOSynchronisationRequestNotification object:nil handler:nil];
+    [self expectationForNotification:CDOSynchronisationResponseNotification object:nil handler:nil];
+
+    [CDOSynchronisationCoordinator synchronise];
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+
+@end

--- a/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation ExampleTests/Tests/CDOUserImportOperationTests.m
+++ b/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation ExampleTests/Tests/CDOUserImportOperationTests.m
@@ -13,6 +13,8 @@
 #import "User.h"
 #import <AGAsyncTestHelper/AGAsyncTestHelper.h>
 #import "CDOGithubAPIClient.h"
+#import <OCMock/OCMock.h>
+#import "CDOJSONFixtureLoader.h"
 
 @interface CDOUserImportOperationTests : XCTestCase
 @property (nonatomic, strong) SQKContextManager *contextManager;
@@ -25,19 +27,18 @@
 - (void)setUp {
 	[super setUp];
 
-	// Set your Github API access token for the CDOGithubAPIClient
-	// See: https://github.com/settings/applications#personal-access-tokens
-	// I'm loading mine from a .plist (ignored in the git repo)
-	NSString *path = [[NSBundle mainBundle] pathForResource:@"GithubToken" ofType:@"plist"];
-	NSDictionary *plistDict = [NSDictionary dictionaryWithContentsOfFile:path];
-	NSString *accessToken = plistDict[@"token"];
-	CDOGithubAPIClient *APIClient = [[CDOGithubAPIClient alloc] initWithAccessToken:accessToken];
+    CDOGithubAPIClient *APIClientMock = OCMClassMock([CDOGithubAPIClient class]);
+    
+    NSArray *usersJSON = [CDOJSONFixtureLoader loadJSONFileNamed:@"users"];
+
+    OCMStub([APIClientMock getUser:@"lukestringer90" error:[OCMArg anyObjectRef]]).andReturn(usersJSON[0]);
+    OCMStub([APIClientMock getUser:@"blork" error:[OCMArg anyObjectRef]]).andReturn(usersJSON[1]);
 
 	NSManagedObjectModel *model = [NSManagedObjectModel mergedModelFromBundles:nil];
 	self.contextManager = [[SQKContextManager alloc] initWithStoreType:NSInMemoryStoreType
 	                                                managedObjectModel:model
 	                                                          storeURL:nil];
-	self.operation = [[CDOUserImportOperation alloc] initWithContextManager:self.contextManager APIClient:APIClient];
+	self.operation = [[CDOUserImportOperation alloc] initWithContextManager:self.contextManager APIClient:APIClientMock];
 	self.queue = [NSOperationQueue new];
 }
 

--- a/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation ExampleTests/Tests/CDOUserImportOperationTests.m
+++ b/Examples/SQKCoreDataOperation Example/SQKCoreDataOperation ExampleTests/Tests/CDOUserImportOperationTests.m
@@ -31,13 +31,13 @@
 	NSString *path = [[NSBundle mainBundle] pathForResource:@"GithubToken" ofType:@"plist"];
 	NSDictionary *plistDict = [NSDictionary dictionaryWithContentsOfFile:path];
 	NSString *accessToken = plistDict[@"token"];
-	[CDOGithubAPIClient sharedInstance].accessToken = accessToken;
+	CDOGithubAPIClient *APIClient = [[CDOGithubAPIClient alloc] initWithAccessToken:accessToken];
 
 	NSManagedObjectModel *model = [NSManagedObjectModel mergedModelFromBundles:nil];
 	self.contextManager = [[SQKContextManager alloc] initWithStoreType:NSInMemoryStoreType
 	                                                managedObjectModel:model
 	                                                          storeURL:nil];
-	self.operation = [[CDOUserImportOperation alloc] initWithContextManager:self.contextManager];
+	self.operation = [[CDOUserImportOperation alloc] initWithContextManager:self.contextManager APIClient:APIClient];
 	self.queue = [NSOperationQueue new];
 }
 


### PR DESCRIPTION
An example of the web service architecture discussed 14/10/14.
Using NSNotifications to begin web operations instead of directly invoking methods allows easier testing and more flexibility.

**Not to be merged at this time.**