### PR TITLE
Added method to delete objects in a context with a predicate.

### DIFF
--- a/Classes/shared/NSManagedObject+SQKAdditions/NSManagedObject+SQKAdditions.h
+++ b/Classes/shared/NSManagedObject+SQKAdditions/NSManagedObject+SQKAdditions.h
@@ -148,6 +148,15 @@ You should call this method from inside a `performBlockAndWait` to avoid threadi
 + (void)sqk_deleteAllObjectsInContext:(NSManagedObjectContext *)context error:(NSError **)error;
 
 /**
+ *  Remove all objects of the class matching the given predicate from the store asynchronously.
+ *
+ *  @param context   The managed object context to use. Must not be nil.
+ *  @param predicate The predicate to be used to filter the objects to be deleted.
+ *  @param error     If there is a problem executing the fetch, upon return contains an instance of NSError that describes the problem.
+ */
++ (void)sqk_deleteAllObjectsInContext:(NSManagedObjectContext *)context withPredicate:(NSPredicate *)predicate error:(NSError **)error;
+
+/**
  *  @name Property description.
  */
 

--- a/Classes/shared/NSManagedObject+SQKAdditions/NSManagedObject+SQKAdditions.m
+++ b/Classes/shared/NSManagedObject+SQKAdditions/NSManagedObject+SQKAdditions.m
@@ -93,6 +93,26 @@ NSString *const SQKDataKitErrorDomain = @"SQKDataKitErrorDomain";
     [objects makeObjectsPerformSelector:@selector(sqk_deleteObject)];
 }
 
++ (void)sqk_deleteAllObjectsInContext:(NSManagedObjectContext *)context withPredicate:(NSPredicate *)predicate error:(NSError **)error
+{
+    NSError *localError = nil;
+    NSFetchRequest *fetchRequest = [self sqk_fetchRequest];
+    fetchRequest.includesPropertyValues = NO;
+    fetchRequest.returnsObjectsAsFaults = NO;
+    fetchRequest.predicate = predicate;
+    NSArray *objects = [context executeFetchRequest:fetchRequest error:&localError];
+    if (localError)
+    {
+        if (error)
+        {
+            *error = localError;
+        }
+        return;
+    }
+    
+    [objects makeObjectsPerformSelector:@selector(sqk_deleteObject)];
+}
+
 + (void)sqk_insertOrUpdate:(NSArray *)remoteData
             uniqueModelKey:(id)modelKey
            uniqueRemoteKey:(id)remoteDataKey

--- a/Project/SQKDataKitTests/SQKManagedObjectControllerTests.m
+++ b/Project/SQKDataKitTests/SQKManagedObjectControllerTests.m
@@ -175,6 +175,32 @@
     XCTAssertNil(error, @"");
 }
 
+- (void)testDeletionWithPredicate
+{
+    NSError *error = nil;
+    NSManagedObjectContext *context = [self.contextManager mainContext];
+    
+    Commit *commit = [Commit sqk_insertInContext:context];
+    commit.sha = @"To delete";
+    commit.date = [NSDate date];
+    
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"sha == 'To delete'"];
+    [Commit sqk_deleteAllObjectsInContext:context withPredicate:predicate error:&error];
+    XCTAssertNil(error, @"");
+    
+    [context save:&error];
+    XCTAssertNil(error, @"");
+    
+    NSFetchRequest *fetchRequest = [Commit sqk_fetchRequest];
+    NSArray *objects = [context executeFetchRequest:fetchRequest error:&error];
+    XCTAssertNil(error, @"");
+    
+    Commit *fetchedCommit = [objects firstObject];
+    
+    XCTAssertEqual([objects count], (NSUInteger)1, @"");
+    XCTAssertEqual(fetchedCommit.sha, @"abcd");
+}
+
 #pragma mark - Other Initialisers
 
 /**


### PR DESCRIPTION
Currently we have delete all in context and delete object. 

This just allows a predicate to be passed so all objects matching the predicate in the given context will be delete.