### PR TITLE
Fixed incorrect entity name being used in Swift projects.

### DIFF
--- a/Classes/shared/NSManagedObject+SQKAdditions/NSManagedObject+SQKAdditions.m
+++ b/Classes/shared/NSManagedObject+SQKAdditions/NSManagedObject+SQKAdditions.m
@@ -18,7 +18,7 @@ NSString *const SQKDataKitErrorDomain = @"SQKDataKitErrorDomain";
     {
         return nil;
     }
-    return NSStringFromClass([self class]);
+    return [[NSStringFromClass([self class]) componentsSeparatedByString:@"."] lastObject];
 }
 
 + (NSEntityDescription *)sqk_entityDescriptionInContext:(NSManagedObjectContext *)context


### PR DESCRIPTION
NSStringFromClass includes namespace when called on a Swift class. Fixes #17.
