### PR TITLE
Added a ManagedObjectController tableview example

### DIFF
--- a/Classes/shared/SQKManagedObjectController/SQKManagedObjectController.h
+++ b/Classes/shared/SQKManagedObjectController/SQKManagedObjectController.h
@@ -154,16 +154,32 @@ typedef void (^SQKManagedObjectControllerObjectsFetchedBlock)(SQKManagedObjectCo
  */
 - (instancetype)initWithManagedObject:(NSManagedObject *)managedObject;
 
+
 /**
  *  Execute the fetch request and store the results in self.managedObjects.
  *  Blocks the main thread. On returning, fetchedObjects will be available.
  *
  *  @param error If there is a problem executing the fetch, upon return contains an instance of
- *NSError that describes the problem.
+ *  NSError that describes the problem.
  *
  *  @return YES if the fetch succeeds, otherwise NO.
  */
 - (BOOL)performFetch:(NSError **)error;
+
+
+/**
+ *  Execute the fetch request and store the results in self.managedObjects.
+ *  Blocks the main thread. On returning, fetchedObjects will be available.
+ *
+ *  @param error If there is a problem executing the fetch, upon return contains an instance of
+ *  NSError that describes the problem.
+ *
+ *  @param notify If NO, does not fire delegate or block callbacks.
+ *
+ *  @return YES if the fetch succeeds, otherwise NO.
+ */
+- (BOOL)performFetch:(NSError **)error notify:(BOOL)shouldNotify;
+
 
 /**
  *  Deleted the fetched objects from self.managedObjectContext and saves.

--- a/Classes/shared/SQKManagedObjectController/SQKManagedObjectController.m
+++ b/Classes/shared/SQKManagedObjectController/SQKManagedObjectController.m
@@ -90,6 +90,11 @@ NSString *const SQKManagedObjectControllerErrorDomain = @"SQKManagedObjectContro
 
 - (BOOL)performFetch:(NSError **)error
 {
+    return [self performFetch:error notify:YES];
+}
+
+- (BOOL)performFetch:(NSError **)error notify:(BOOL)shouldNotify
+{
     if (!self.fetchRequest)
     {
         *error = [NSError errorWithDomain:SQKManagedObjectControllerErrorDomain
@@ -108,15 +113,18 @@ NSString *const SQKManagedObjectControllerErrorDomain = @"SQKManagedObjectContro
         }];
     self.managedObjects = [fetchedObjects objectsAtIndexes:indexes];
 
-    NSIndexSet *allIndexes = [self.managedObjects sqk_indexesOfObjects];
-    if ([self.delegate respondsToSelector:@selector(controller:fetchedObjects:error:)])
-    {
-        [self.delegate controller:self fetchedObjects:allIndexes error:error];
+    if (shouldNotify) {
+        NSIndexSet *allIndexes = [self.managedObjects sqk_indexesOfObjects];
+        if ([self.delegate respondsToSelector:@selector(controller:fetchedObjects:error:)])
+        {
+            [self.delegate controller:self fetchedObjects:allIndexes error:error];
+        }
+        if (self.fetchedObjectsBlock)
+        {
+            self.fetchedObjectsBlock(self, allIndexes, *error);
+        }
     }
-    if (self.fetchedObjectsBlock)
-    {
-        self.fetchedObjectsBlock(self, allIndexes, *error);
-    }
+    
     return error ? NO : YES;
 }
 

--- a/Project/SQKDataKit.xcodeproj/project.pbxproj
+++ b/Project/SQKDataKit.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		A3F70A90185A041D00C0A389 /* SQKMetricsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = A3F70A8F185A041D00C0A389 /* SQKMetricsViewController.m */; };
 		AFFC25DF40274C52A419927E /* libPods-SQKDataKit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2868235566F44D78765833F /* libPods-SQKDataKit.a */; };
 		C8CFF472097F4E5BBA949BDB /* libPods-SQKDataKitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4AB52E80206042BCB848D249 /* libPods-SQKDataKitTests.a */; };
+		CB40EDD41A65633900181627 /* SQKAlternateCommitsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = CB40EDD31A65633900181627 /* SQKAlternateCommitsViewController.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -97,6 +98,8 @@
 		A3F70A8E185A041D00C0A389 /* SQKMetricsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SQKMetricsViewController.h; sourceTree = "<group>"; };
 		A3F70A8F185A041D00C0A389 /* SQKMetricsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SQKMetricsViewController.m; sourceTree = "<group>"; };
 		B2868235566F44D78765833F /* libPods-SQKDataKit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SQKDataKit.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		CB40EDD21A65633900181627 /* SQKAlternateCommitsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SQKAlternateCommitsViewController.h; sourceTree = "<group>"; };
+		CB40EDD31A65633900181627 /* SQKAlternateCommitsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SQKAlternateCommitsViewController.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -177,6 +180,8 @@
 				A3F70A8F185A041D00C0A389 /* SQKMetricsViewController.m */,
 				A3DC7C991868731100C45DB0 /* SQKJSONLoader.h */,
 				A3DC7C9A1868731100C45DB0 /* SQKJSONLoader.m */,
+				CB40EDD21A65633900181627 /* SQKAlternateCommitsViewController.h */,
+				CB40EDD31A65633900181627 /* SQKAlternateCommitsViewController.m */,
 			);
 			name = Controller;
 			sourceTree = "<group>";
@@ -435,6 +440,7 @@
 			files = (
 				A3F70A8D1859D80C00C0A389 /* SQKCommitCell.m in Sources */,
 				A3C66D06185A20CE007AE9B5 /* NaiveImportOperation.m in Sources */,
+				CB40EDD41A65633900181627 /* SQKAlternateCommitsViewController.m in Sources */,
 				A34BF3B4184F41D400F2E3B4 /* SQKCommitsViewController.m in Sources */,
 				22780673196AB3DE00F8DED4 /* SQKCommitDetailViewController.m in Sources */,
 				A31AB0E71857769D00B240AB /* Commit.m in Sources */,

--- a/Project/SQKDataKit/SQKAlternateCommitsViewController.h
+++ b/Project/SQKDataKit/SQKAlternateCommitsViewController.h
@@ -1,0 +1,16 @@
+//
+//  SQKAlternateCommitsViewController.h
+//  SQKDataKit
+//
+//  Created by Sam Oakley on 13/01/2015.
+//  Copyright (c) 2015 3Squared. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@class SQKContextManager;
+@interface SQKAlternateCommitsViewController : UITableViewController
+
+- (instancetype)initWithContextManager:(SQKContextManager *)contextManager;
+
+@end

--- a/Project/SQKDataKit/SQKAlternateCommitsViewController.m
+++ b/Project/SQKDataKit/SQKAlternateCommitsViewController.m
@@ -1,0 +1,175 @@
+//
+//  SQKAlternateCommitsViewController.m
+//  SQKDataKit
+//
+//  Created by Sam Oakley on 13/01/2015.
+//  Copyright (c) 2015 3Squared. All rights reserved.
+//
+
+#import "SQKAlternateCommitsViewController.h"
+#import "SQKJSONLoader.h"
+#import "SQKCommitCell.h"
+#import "OptimisedImportOperation.h"
+#import "Commit.h"
+#import "SQKCommitDetailViewController.h"
+#import <SQKDataKit/SQKContextManager.h>
+#import <SQKDataKit/NSManagedObject+SQKAdditions.h>
+#import <SQKDataKit/SQKManagedObjectController.h>
+
+@interface SQKAlternateCommitsViewController () <SQKManagedObjectControllerDelegate>
+@property (nonatomic, strong) NSOperationQueue *queue;
+@property (nonatomic, strong) SQKContextManager *contextManager;
+@property (nonatomic, strong) SQKManagedObjectController *controller;
+@property (nonatomic, strong) id json;
+@end
+
+@implementation SQKAlternateCommitsViewController
+
+- (instancetype)initWithContextManager:(SQKContextManager *)contextManager
+{
+    self = [super init];
+    if (self)
+    {
+        self.contextManager = contextManager;
+        self.title = @"Alt.";
+        self.tabBarItem = [[UITabBarItem alloc] initWithTitle:self.title
+                                                        image:[UIImage imageNamed:@"list"]
+                                                          tag:0];
+        self.queue = [[NSOperationQueue alloc] init];
+        self.json = [SQKJSONLoader loadJSONFileName:@"data_1500"];
+        
+        NSFetchRequest *request = [Commit sqk_fetchRequest];
+        request.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"date" ascending:NO]];
+
+        self.controller =
+        [[SQKManagedObjectController alloc] initWithFetchRequest:request
+                                            managedObjectContext:[self.contextManager mainContext]];
+        self.controller.delegate = self;
+    }
+    return self;
+}
+
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+    [self.tableView registerClass:[SQKCommitCell class]
+           forCellReuseIdentifier:NSStringFromClass([SQKCommitCell class])];
+    
+    self.refreshControl = [[UIRefreshControl alloc] init];
+    [self.refreshControl addTarget:self
+                            action:@selector(refresh:)
+                  forControlEvents:UIControlEventValueChanged];
+    
+    [self.controller performFetch:nil];
+}
+
+- (void)refresh:(id)sender
+{
+    [self.refreshControl beginRefreshing];
+    OptimisedImportOperation *importOperation =
+    [[OptimisedImportOperation alloc] initWithContextManager:self.contextManager
+                                                        data:self.json];
+    __weak typeof(self) weakSelf = self;
+    [importOperation setCompletionBlock:^{
+        [[NSOperationQueue mainQueue]
+         addOperationWithBlock:^{ [weakSelf.refreshControl endRefreshing]; }];
+    }];
+    
+    [self.queue addOperation:importOperation];
+}
+
+#pragma mark - UITableViewDelegate
+
+- (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
+{
+    return SQKCommitCellHeight;
+}
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
+{
+    Commit *commit = [self.controller.managedObjects objectAtIndex:indexPath.row];
+    SQKCommitDetailViewController *detailVC = [[SQKCommitDetailViewController alloc] initWithCommit:commit];
+    [self.navigationController pushViewController:detailVC animated:YES];
+}
+
+#pragma mark - UITableViewDataSource
+
+- (UITableViewCell *)tableView:(UITableView *)tableView
+         cellForRowAtIndexPath:(NSIndexPath *)indexPath
+{
+    SQKCommitCell *cell =
+    (SQKCommitCell *)[self.tableView dequeueReusableCellWithIdentifier:NSStringFromClass([SQKCommitCell class])
+                                         forIndexPath:indexPath];
+
+    Commit *commit = [self.controller.managedObjects objectAtIndex:indexPath.row];
+
+    cell.authorNameLabel.text = commit.authorName;
+    cell.authorEmailLabel.text = commit.authorEmail;
+    cell.dateLabel.text = [commit.date description];
+    cell.shaLabel.text = commit.sha;
+    cell.messageLabel.text = commit.message;
+    
+    return cell;
+}
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView
+{
+    return 1;
+}
+
+-(NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
+{
+    return [self.controller.managedObjects count];
+}
+
+- (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath
+{
+    return YES;
+}
+
+
+- (void)tableView:(UITableView *)tableView
+commitEditingStyle:(UITableViewCellEditingStyle)editingStyle
+forRowAtIndexPath:(NSIndexPath *)indexPath
+{
+    if (editingStyle == UITableViewCellEditingStyleDelete)
+    {
+        Commit *commit = [self.controller.managedObjects objectAtIndex:indexPath.row];
+        [commit.managedObjectContext performBlock:^{
+            [commit sqk_deleteObject];
+            [commit.managedObjectContext save:nil];
+        }];
+    }
+}
+
+
+#pragma mark - SQKManagedObjectControllerDelegate
+
+-(void)controller:(SQKManagedObjectController *)controller fetchedObjects:(NSIndexSet *)fetchedObjectIndexes error:(NSError **)error
+{
+    NSLog(@"fetchedObjects");
+    [self.tableView reloadData];
+}
+
+-(void)controller:(SQKManagedObjectController *)controller didInsertObjects:(NSIndexSet *)insertedObjectIndexes
+{
+    NSLog(@"didInsertObjects");
+    for (Commit *commit in [self.controller.managedObjects objectsAtIndexes:insertedObjectIndexes]) {
+        NSLog(@"Inserted commit: %@", commit.sha);
+    }
+    [self.controller performFetch:nil];
+    [self.tableView reloadData];
+}
+
+-(void)controller:(SQKManagedObjectController *)controller didDeleteObjects:(NSIndexSet *)deletedObjectIndexes
+{
+    NSLog(@"didDeleteObjects");
+    for (Commit *commit in [self.controller.managedObjects objectsAtIndexes:deletedObjectIndexes]) {
+        NSLog(@"Deleted commit: %@", commit);
+    }
+    [self.controller performFetch:nil];
+    [self.tableView reloadData];
+}
+
+@end

--- a/Project/SQKDataKit/SQKAppDelegate.m
+++ b/Project/SQKDataKit/SQKAppDelegate.m
@@ -9,6 +9,7 @@
 #import "SQKAppDelegate.h"
 #import "SQKCommitsViewController.h"
 #import "SQKMetricsViewController.h"
+#import "SQKAlternateCommitsViewController.h"
 
 #import <SQKDataKit/SQKContextManager.h>
 
@@ -50,9 +51,15 @@ static BOOL isRunningTests(void)
     UINavigationController *metricsNavController =
         [[UINavigationController alloc] initWithRootViewController:metricsViewController];
 
+    
+    SQKAlternateCommitsViewController *altCommitsViewController = [[SQKAlternateCommitsViewController alloc]
+                                                                   initWithContextManager:self.contextManager];
+    UINavigationController *altCommitsNavController =
+    [[UINavigationController alloc] initWithRootViewController:altCommitsViewController];
+
 
     UITabBarController *tabBarController = [[UITabBarController alloc] init];
-    tabBarController.viewControllers = @[metricsNavController, commitsNavController];
+    tabBarController.viewControllers = @[metricsNavController, commitsNavController, altCommitsNavController];
 
     self.window.rootViewController = tabBarController;
     [self.window makeKeyAndVisible];


### PR DESCRIPTION
Added an example of using SQKManagedObjectController in place of an NSFetchedResultsController to back a UITableView.

Why? It shows that the object controller can do the same as an FRC, but in a less opaque way (you can see what's happening). Performance will be worse though, since all fetched objects are loaded into memory at once. FRCs have some wicked bugs though (like with collection views).