### PR TITLE
Finish the core data operation if saving errors

### DIFF
--- a/Classes/shared/SQKCoreDataOperation/SQKCoreDataOperation.m
+++ b/Classes/shared/SQKCoreDataOperation/SQKCoreDataOperation.m
@@ -99,10 +99,14 @@
                                                      name:NSManagedObjectContextDidSaveNotification
                                                    object:nil];
 
-        NSError *error = nil;
-        [managedObjectContext save:&error];
-        [self addError:error];
-    }
+		NSError *error = nil;
+		[managedObjectContext save:&error];
+		if (error)
+		{
+			[self addError:error];
+			[self finishOperation];
+		}
+	}
 }
 
 - (void)finishOperation

--- a/Project/SQKDataKit.xcodeproj/project.pbxproj
+++ b/Project/SQKDataKit.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		A34BF3D4184F456B00F2E3B4 /* SQKContextManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A34BF3D3184F456B00F2E3B4 /* SQKContextManagerTests.m */; };
 		A34BF3D9184F471E00F2E3B4 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A34BF3D8184F471E00F2E3B4 /* CoreData.framework */; };
 		A34BF42B184F6D0000F2E3B4 /* NSPersistentStoreCoordinatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A34BF42A184F6D0000F2E3B4 /* NSPersistentStoreCoordinatorTests.m */; };
+		A37F4E441B29A95A0087D344 /* SQKErroringManagedObjectContext.m in Sources */ = {isa = PBXBuildFile; fileRef = A37F4E431B29A95A0087D344 /* SQKErroringManagedObjectContext.m */; };
 		A3C66D06185A20CE007AE9B5 /* NaiveImportOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = A3C66D05185A20CE007AE9B5 /* NaiveImportOperation.m */; };
 		A3C66D09185B2A19007AE9B5 /* GitDataImportOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = A3C66D08185B2A19007AE9B5 /* GitDataImportOperation.m */; };
 		A3DC7C9B1868731100C45DB0 /* SQKJSONLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = A3DC7C9A1868731100C45DB0 /* SQKJSONLoader.m */; };
@@ -98,6 +99,8 @@
 		A34BF3D3184F456B00F2E3B4 /* SQKContextManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SQKContextManagerTests.m; sourceTree = "<group>"; };
 		A34BF3D8184F471E00F2E3B4 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 		A34BF42A184F6D0000F2E3B4 /* NSPersistentStoreCoordinatorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSPersistentStoreCoordinatorTests.m; sourceTree = "<group>"; };
+		A37F4E421B29A95A0087D344 /* SQKErroringManagedObjectContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SQKErroringManagedObjectContext.h; sourceTree = "<group>"; };
+		A37F4E431B29A95A0087D344 /* SQKErroringManagedObjectContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SQKErroringManagedObjectContext.m; sourceTree = "<group>"; };
 		A3C66D04185A20CE007AE9B5 /* NaiveImportOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NaiveImportOperation.h; sourceTree = "<group>"; };
 		A3C66D05185A20CE007AE9B5 /* NaiveImportOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = NaiveImportOperation.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		A3C66D07185B2A19007AE9B5 /* GitDataImportOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GitDataImportOperation.h; sourceTree = "<group>"; };
@@ -274,11 +277,8 @@
 		A34BF3C2184F41D400F2E3B4 /* SQKDataKitTests */ = {
 			isa = PBXGroup;
 			children = (
-				A34BF3D3184F456B00F2E3B4 /* SQKContextManagerTests.m */,
-				22BB628D1919256B00EEEFCE /* SQKManagedObjectControllerTests.m */,
-				A34BF42A184F6D0000F2E3B4 /* NSPersistentStoreCoordinatorTests.m */,
-				A328BAC01850921000267F2E /* NSManagedObjectTests.m */,
-				A30FAE8E1855DFBB008784C6 /* SQKCoreDataOperationTests.m */,
+				A37F4E3E1B29A85D0087D344 /* Mocks */,
+				A37F4E3C1B29A8280087D344 /* Tests */,
 				A34BF3C3184F41D500F2E3B4 /* Supporting Files */,
 			);
 			path = SQKDataKitTests;
@@ -291,6 +291,27 @@
 				A34BF3C5184F41D500F2E3B4 /* InfoPlist.strings */,
 			);
 			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		A37F4E3C1B29A8280087D344 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				A34BF3D3184F456B00F2E3B4 /* SQKContextManagerTests.m */,
+				22BB628D1919256B00EEEFCE /* SQKManagedObjectControllerTests.m */,
+				A34BF42A184F6D0000F2E3B4 /* NSPersistentStoreCoordinatorTests.m */,
+				A328BAC01850921000267F2E /* NSManagedObjectTests.m */,
+				A30FAE8E1855DFBB008784C6 /* SQKCoreDataOperationTests.m */,
+			);
+			name = Tests;
+			sourceTree = "<group>";
+		};
+		A37F4E3E1B29A85D0087D344 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				A37F4E421B29A95A0087D344 /* SQKErroringManagedObjectContext.h */,
+				A37F4E431B29A95A0087D344 /* SQKErroringManagedObjectContext.m */,
+			);
+			name = Mocks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -486,6 +507,7 @@
 				A34BF42B184F6D0000F2E3B4 /* NSPersistentStoreCoordinatorTests.m in Sources */,
 				22BB628E1919256B00EEEFCE /* SQKManagedObjectControllerTests.m in Sources */,
 				A34BF3D4184F456B00F2E3B4 /* SQKContextManagerTests.m in Sources */,
+				A37F4E441B29A95A0087D344 /* SQKErroringManagedObjectContext.m in Sources */,
 				A30FAE8F1855DFBB008784C6 /* SQKCoreDataOperationTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Project/SQKDataKitTests/SQKErroringManagedObjectContext.h
+++ b/Project/SQKDataKitTests/SQKErroringManagedObjectContext.h
@@ -1,0 +1,13 @@
+//
+//  SQKErroringManagedObjectContext.h
+//  SQKDataKit
+//
+//  Created by Luke Stringer on 11/06/2015.
+//  Copyright (c) 2015 3Squared. All rights reserved.
+//
+
+#import <CoreData/CoreData.h>
+
+@interface SQKErroringManagedObjectContext : NSManagedObjectContext
+
+@end

--- a/Project/SQKDataKitTests/SQKErroringManagedObjectContext.m
+++ b/Project/SQKDataKitTests/SQKErroringManagedObjectContext.m
@@ -1,0 +1,19 @@
+//
+//  SQKErroringManagedObjectContext.m
+//  SQKDataKit
+//
+//  Created by Luke Stringer on 11/06/2015.
+//  Copyright (c) 2015 3Squared. All rights reserved.
+//
+
+#import "SQKErroringManagedObjectContext.h"
+
+@implementation SQKErroringManagedObjectContext
+
+- (BOOL)save:(NSError *__autoreleasing *)error
+{
+	*error = [NSError errorWithDomain:@"SQKErroringManagedObjectContext" code:0 userInfo:nil];
+	return NO;
+}
+
+@end


### PR DESCRIPTION
This addresses issue #62. However there is a problem:

The changes to `SQKCoreDataOperationTests` now cause the `testInitialisingWithObjectAsync` test in `SQKManagedObjectControllerTests` to hang. If the implementation of `performWorkWithPrivateContext:` of the `ConcreteDataImportOperation` class is removed then test suite finishes. However this then means that the `testFinishesWhenSavingErrors` test (which is reliant on this method implementation) fails.