### PR TITLE
Use NSAssert to check MOC saves without errors in operations.

### DIFF
--- a/Classes/shared/SQKCoreDataOperation/SQKCoreDataOperation.m
+++ b/Classes/shared/SQKCoreDataOperation/SQKCoreDataOperation.m
@@ -101,6 +101,9 @@
 
         NSError *error = nil;
         [managedObjectContext save:&error];
+        
+        NSAssert(error == nil, @"Save errored");
+        
         [self addError:error];
     }
 }


### PR DESCRIPTION
When the context does not successfully save from within an operation then
the error is made available from the error property. However recovering
from an error once the operation has finished is next to impossible as you
do not have access to the context that failed. Therefore is it better to
just hard crash and fix the bug when you know the save failed.