### PR TITLE
Add method to destroy and rebuild persistent store

### DIFF
--- a/Classes/shared/ContextManager/SQKContextManager.h
+++ b/Classes/shared/ContextManager/SQKContextManager.h
@@ -24,6 +24,26 @@
 @interface SQKContextManager : NSObject
 
 /**
+ *  The store type used to create the persistent store.
+ */
+@property (nonatomic, strong, readonly) NSString *storeType;
+
+/**
+ *  The managed object model used to create the persistent store.
+ */
+@property (nonatomic, strong, readonly) NSManagedObjectModel *managedObjectModel;
+
+/**
+ *  An array of model names used when performing migration.
+ */
+@property (nonatomic, strong, readonly) NSArray *modelNames;
+
+/**
+ *  A URL to the sqlite file used for the persistent store.
+ */
+@property (nonatomic, strong, readonly) NSURL *storeURL;
+
+/**
  *  The persistent store coordinator used by the context manager.
  */
 @property (nonatomic, strong, readonly) NSPersistentStoreCoordinator *persistentStoreCoordinator;

--- a/Classes/shared/ContextManager/SQKContextManager.h
+++ b/Classes/shared/ContextManager/SQKContextManager.h
@@ -42,14 +42,6 @@
                 managedObjectModel:(NSManagedObjectModel *)managedObjectModel
     orderedManagedObjectModelNames:(NSArray *)modelNames
                           storeURL:(NSURL *)storeURL;
-/**
- *  Initialises a context manager with a persistent store coordinator.
- *
- *  @param persistentStoreCoordinator A configured persistent store coordinator.
- *
- *  @return A context manager.
- */
-- (instancetype)initWithPersistentStoreCoordinator:(NSPersistentStoreCoordinator *)persistentStoreCoordinator;
 
 /**
  *  The main managed object context to be used for UI based Core Data work (on the main thread). A

--- a/Classes/shared/ContextManager/SQKContextManager.h
+++ b/Classes/shared/ContextManager/SQKContextManager.h
@@ -90,6 +90,6 @@
  *
  *  @return boolean value to indicate success of persistent store tear down.
  */
-- (bool)resetPersistentStore;
+- (BOOL)destroyAndRebuildPersistentStore:(NSError **)error;
 
 @end

--- a/Classes/shared/ContextManager/SQKContextManager.h
+++ b/Classes/shared/ContextManager/SQKContextManager.h
@@ -65,4 +65,11 @@
  */
 - (NSManagedObjectContext *)newPrivateContext;
 
+/**
+ *  Tear down persistent store backed by coordinator.
+ *
+ *  @return boolean value to indicate success of persistent store tear down.
+ */
+- (bool)resetPersistentStore;
+
 @end

--- a/Classes/shared/ContextManager/SQKContextManager.h
+++ b/Classes/shared/ContextManager/SQKContextManager.h
@@ -86,7 +86,14 @@
 - (NSManagedObjectContext *)newPrivateContext;
 
 /**
- *  Tear down persistent store backed by coordinator.
+ *  Tear down persistent store backed by coordinator. This will attempt to remove 
+ *  the persistent store and delete the local database file.
+ *
+ *  On a successful attempt to delete the store and database, the persistent store
+ *  is rebuilt and the main context is recreated on the next call to `mainContext`.
+ *
+ *  @param error - An NSError used to capture any errors encountered when attempting
+ *  to remove the persistent store or delete the local database file from disk.
  *
  *  @return boolean value to indicate success of persistent store tear down.
  */

--- a/Classes/shared/ContextManager/SQKContextManager.m
+++ b/Classes/shared/ContextManager/SQKContextManager.m
@@ -38,7 +38,7 @@
     
     if(self)
     {
-        _persistentStoreCoordinator = [NSPersistentStoreCoordinator sqk_storeCoordinatorWithStoreType:storeType
+        self.persistentStoreCoordinator = [NSPersistentStoreCoordinator sqk_storeCoordinatorWithStoreType:storeType
                                                                                    managedObjectModel:managedObjectModel
                                                                        orderedManagedObjectModelNames:modelNames
                                                                                              storeURL:storeURL];
@@ -132,19 +132,17 @@
     return context;
 }
 
-- (bool)resetPersistentStore
+- (BOOL)destroyAndRebuildPersistentStore:(NSError **)error
 {
     NSPersistentStore *persistentStore = self.persistentStoreCoordinator.persistentStores.firstObject;
     
     if(persistentStore)
     {
-        NSError *error = nil;
-        
-        [self.persistentStoreCoordinator removePersistentStore:persistentStore error:&error];
+        [self.persistentStoreCoordinator removePersistentStore:persistentStore error:error];
         
         if(!error)
         {
-            [[NSFileManager defaultManager] removeItemAtURL:self.storeURL error:&error];
+            [[NSFileManager defaultManager] removeItemAtURL:self.storeURL error:error];
             
             if(!error)
             {
@@ -154,19 +152,7 @@
                 
                 return YES;
             }
-            else
-            {
-                NSLog(@"Error removing persistent store at url: %@", self.storeURL);
-            }
         }
-        else
-        {
-            NSLog(@"Error gathering persistent store for removal.");
-        }
-    }
-    else
-    {
-        NSLog(@"Persistent store not found.");
     }
     
     return NO;

--- a/Classes/shared/ContextManager/SQKContextManager.m
+++ b/Classes/shared/ContextManager/SQKContextManager.m
@@ -132,6 +132,46 @@
     return context;
 }
 
+- (bool)resetPersistentStore
+{
+    NSPersistentStore *persistentStore = self.persistentStoreCoordinator.persistentStores.firstObject;
+    
+    if(persistentStore)
+    {
+        NSError *error = nil;
+        
+        [self.persistentStoreCoordinator removePersistentStore:persistentStore error:&error];
+        
+        if(!error)
+        {
+            [[NSFileManager defaultManager] removeItemAtURL:self.storeURL error:&error];
+            
+            if(!error)
+            {
+                _mainContext = nil;
+                
+                self.persistentStoreCoordinator = [NSPersistentStoreCoordinator sqk_storeCoordinatorWithStoreType:self.storeType managedObjectModel:self.managedObjectModel orderedManagedObjectModelNames:self.modelNames storeURL:self.storeURL];
+                
+                return YES;
+            }
+            else
+            {
+                NSLog(@"Error removing persistent store at url: %@", self.storeURL);
+            }
+        }
+        else
+        {
+            NSLog(@"Error gathering persistent store for removal.");
+        }
+    }
+    else
+    {
+        NSLog(@"Persistent store not found.");
+    }
+    
+    return NO;
+}
+
 - (void)dealloc
 {
     [[NSNotificationCenter defaultCenter] removeObserver:self

--- a/Classes/shared/ContextManager/SQKContextManager.m
+++ b/Classes/shared/ContextManager/SQKContextManager.m
@@ -11,43 +11,48 @@
 #import "NSManagedObjectContext+SQKAdditions.h"
 
 @interface SQKContextManager ()
+
 @property (nonatomic, strong, readwrite) NSString *storeType;
 @property (nonatomic, strong, readwrite) NSManagedObjectModel *managedObjectModel;
-@property (nonatomic, strong, readwrite) NSManagedObjectContext *mainContext;
+@property (nonatomic, strong, readwrite) NSArray *modelNames;
+@property (nonatomic, strong, readwrite) NSURL *storeURL;
+
 @property (nonatomic, strong, readwrite) NSPersistentStoreCoordinator *persistentStoreCoordinator;
+@property (nonatomic, strong, readwrite) NSManagedObjectContext *mainContext;
+
 @end
 
 @implementation SQKContextManager
 
 - (instancetype)initWithStoreType:(NSString *)storeType
-                managedObjectModel:(NSManagedObjectModel *)managedObjectModel
-    orderedManagedObjectModelNames:(NSArray *)modelNames
-                          storeURL:(NSURL *)storeURL
+               managedObjectModel:(NSManagedObjectModel *)managedObjectModel
+   orderedManagedObjectModelNames:(NSArray *)modelNames
+                         storeURL:(NSURL *)storeURL
 {
     if (!storeType || !managedObjectModel || ![[SQKContextManager validStoreTypes] containsObject:storeType])
     {
         return nil;
     }
-
-    return [self initWithPersistentStoreCoordinator:[NSPersistentStoreCoordinator sqk_storeCoordinatorWithStoreType:storeType
-                                                                                                 managedObjectModel:managedObjectModel
-                                                                                     orderedManagedObjectModelNames:modelNames
-                                                                                                           storeURL:storeURL]];
-}
-
-- (instancetype)initWithPersistentStoreCoordinator:(NSPersistentStoreCoordinator *)persistentStoreCoordinator
-{
-    if (!persistentStoreCoordinator)
+    
+    self = [super init];
+    
+    if(self)
     {
-        return nil;
-    }
-    if (self = [super init])
-    {
-        _persistentStoreCoordinator = persistentStoreCoordinator;
+        _persistentStoreCoordinator = [NSPersistentStoreCoordinator sqk_storeCoordinatorWithStoreType:storeType
+                                                                                   managedObjectModel:managedObjectModel
+                                                                       orderedManagedObjectModelNames:modelNames
+                                                                                             storeURL:storeURL];
+        
+        self.storeType = storeType;
+        self.managedObjectModel = managedObjectModel;
+        self.modelNames = modelNames;
+        self.storeURL = storeURL;
+        
         [self observeForSavedNotification];
     }
-
+    
     return self;
+    
 }
 
 + (NSArray *)validStoreTypes

--- a/Project/SQKDataKitTests/SQKContextManagerTests.m
+++ b/Project/SQKDataKitTests/SQKContextManagerTests.m
@@ -67,15 +67,6 @@
     XCTAssertEqualObjects(self.contextManager.persistentStoreCoordinator.managedObjectModel, self.managedObjectModel, @"");
 }
 
-- (void)testInitialisesWithSPersistentStoreCoordinator
-{
-    id storeCoordinator = [OCMockObject mockForClass:[NSPersistentStoreCoordinator class]];
-
-    self.contextManager = [[SQKContextManager alloc] initWithPersistentStoreCoordinator:storeCoordinator];
-    XCTAssertNotNil(self.contextManager, @"");
-    XCTAssertEqualObjects(self.contextManager.persistentStoreCoordinator, storeCoordinator, @"");
-}
-
 - (void)testReturnsNilWithNoStoreType
 {
     self.contextManager = [[SQKContextManager alloc] initWithStoreType:nil
@@ -229,6 +220,31 @@
 
 	[self waitForExpectationsWithTimeout:2.0 handler:nil];
     XCTAssertEqualObjects([commit sha], @"Edited in a private context", @"");
+}
+
+- (void)testPersistentStoreIsTornDown
+{
+    Commit *commit = [Commit sqk_insertInContext:self.contextManager.mainContext];
+    
+    commit.message = @"Persistent Store Tear Down";
+    
+    [self.contextManager.mainContext save:nil];
+    
+    NSFetchRequest *fetchRequest = [Commit sqk_fetchRequest];
+    
+    NSInteger count = [self.contextManager.mainContext countForFetchRequest:fetchRequest error:nil];
+    
+    NSLog(@"Found %li entities", count);
+    
+    NSError *error = nil;
+    
+    [self.contextManager destroyAndRebuildPersistentStore:&error];
+    
+    count = [self.contextManager.mainContext countForFetchRequest:fetchRequest error:nil];
+    
+    NSLog(@"Found %li entities", count);
+    
+    XCTAssertEqual(count, 0);
 }
 
 @end

--- a/Project/SQKDataKitTests/SQKContextManagerTests.m
+++ b/Project/SQKDataKitTests/SQKContextManagerTests.m
@@ -232,19 +232,19 @@
     
     NSFetchRequest *fetchRequest = [Commit sqk_fetchRequest];
     
-    NSInteger count = [self.contextManager.mainContext countForFetchRequest:fetchRequest error:nil];
+    NSInteger countForFetchRequest = [self.contextManager.mainContext countForFetchRequest:fetchRequest error:nil];
     
-    NSLog(@"Found %li entities", count);
+    NSLog(@"Count for fetch request returned %li entities", countForFetchRequest);
     
     NSError *error = nil;
     
     [self.contextManager destroyAndRebuildPersistentStore:&error];
     
-    count = [self.contextManager.mainContext countForFetchRequest:fetchRequest error:nil];
+    countForFetchRequest = [self.contextManager.mainContext countForFetchRequest:fetchRequest error:nil];
     
-    NSLog(@"Found %li entities", count);
+    NSLog(@"Count for fetch request returned %li entities", countForFetchRequest);
     
-    XCTAssertEqual(count, 0);
+    XCTAssertEqual(countForFetchRequest, 0);
 }
 
 @end


### PR DESCRIPTION
As a means to facilitate tearing down the persistent store entirely, I have added a method to remove the persistent store from the coordinator and delete the local database file on disk.

This method accepts an `NSError` as an argument to capture errors and also returns a boolean to indicate the success of the tear down process.