### PR TITLE
Switch "Fetched" view controllers to be subclasses of UIViewController, fix storyboard use

### DIFF
--- a/Classes/ios/SQKFetchedCollectionViewController/SQKFetchedCollectionViewController.h
+++ b/Classes/ios/SQKFetchedCollectionViewController/SQKFetchedCollectionViewController.h
@@ -10,7 +10,8 @@
 @import CoreData;
 @import UIKit;
 
-@interface SQKFetchedCollectionViewController : UICollectionViewController <NSFetchedResultsControllerDelegate, UISearchBarDelegate>
+IB_DESIGNABLE
+@interface SQKFetchedCollectionViewController : UIViewController <NSFetchedResultsControllerDelegate, UISearchBarDelegate>
 
 /**
  *  Initialises a Core Data-backed UICollectionViewController with a search bar.
@@ -36,6 +37,11 @@
 /**
  *  The collection view shown by the view controller.
  */
+@property (strong, nonatomic) IBOutlet UICollectionView *collectionView;
+
+/**
+ *  The collection view layout used by the view controller.
+ */
 @property (strong, nonatomic) UICollectionViewLayout *layout;
 
 /**
@@ -51,7 +57,7 @@
  *  executed fetch requests take longer when sections are used. When searching this is
  *  especially noticable as a new fetch request is executed upon each key stroke during search.
  */
-@property (nonatomic, assign) BOOL showsSectionsWhenSearching;
+@property (nonatomic, assign) IBInspectable BOOL showsSectionsWhenSearching;
 
 /**
  *  The managed object context backing the fetched results controller.
@@ -67,7 +73,7 @@
  *  BOOL that when set to YES sets a search bar is added to the top of the collection view.
  *  Default is set to YES
  */
-@property (nonatomic, assign) BOOL searchingEnabled;
+@property (nonatomic, assign) IBInspectable BOOL searchingEnabled;
 
 /**
  *  Exposing the search bar so it can be customised.

--- a/Classes/ios/SQKFetchedCollectionViewController/SQKFetchedCollectionViewController.h
+++ b/Classes/ios/SQKFetchedCollectionViewController/SQKFetchedCollectionViewController.h
@@ -34,11 +34,6 @@
 - (instancetype)initWithCollectionViewLayout:(UICollectionViewLayout *)layout context:(NSManagedObjectContext *)context searchingEnabled:(BOOL)searchingEnabled;
 
 /**
- *  The collection view shown by the view controller.
- */
-@property (strong, nonatomic) UICollectionViewLayout *collectionViewLayout;
-
-/**
  *  An optional refresh control shown when pulling down the collectionview.
  *  Set this in your subclass.
  */

--- a/Classes/ios/SQKFetchedCollectionViewController/SQKFetchedCollectionViewController.h
+++ b/Classes/ios/SQKFetchedCollectionViewController/SQKFetchedCollectionViewController.h
@@ -10,7 +10,7 @@
 @import CoreData;
 @import UIKit;
 
-@interface SQKFetchedCollectionViewController : UIViewController <UICollectionViewDelegate, UICollectionViewDataSource, NSFetchedResultsControllerDelegate, UISearchBarDelegate>
+@interface SQKFetchedCollectionViewController : UICollectionViewController <NSFetchedResultsControllerDelegate, UISearchBarDelegate>
 
 /**
  *  Initialises a Core Data-backed UICollectionViewController with a search bar.
@@ -36,8 +36,7 @@
 /**
  *  The collection view shown by the view controller.
  */
-@property (strong, nonatomic, readonly) UICollectionView *collectionView;
-@property (strong, nonatomic, readonly) UICollectionViewLayout *collectionViewLayout;
+@property (strong, nonatomic) UICollectionViewLayout *collectionViewLayout;
 
 /**
  *  An optional refresh control shown when pulling down the collectionview.

--- a/Classes/ios/SQKFetchedCollectionViewController/SQKFetchedCollectionViewController.h
+++ b/Classes/ios/SQKFetchedCollectionViewController/SQKFetchedCollectionViewController.h
@@ -34,6 +34,11 @@
 - (instancetype)initWithCollectionViewLayout:(UICollectionViewLayout *)layout context:(NSManagedObjectContext *)context searchingEnabled:(BOOL)searchingEnabled;
 
 /**
+ *  The collection view shown by the view controller.
+ */
+@property (strong, nonatomic) UICollectionViewLayout *layout;
+
+/**
  *  An optional refresh control shown when pulling down the collectionview.
  *  Set this in your subclass.
  */

--- a/Classes/ios/SQKFetchedCollectionViewController/SQKFetchedCollectionViewController.m
+++ b/Classes/ios/SQKFetchedCollectionViewController/SQKFetchedCollectionViewController.m
@@ -27,22 +27,9 @@
 
 @implementation SQKFetchedCollectionViewController
 
-- (instancetype)initWithCollectionViewLayout:(UICollectionViewLayout *)layout context:(NSManagedObjectContext *)context
-{
-    self = [super initWithCollectionViewLayout:layout];
-    if (self)
-    {
-        self.managedObjectContext = context;
-        self.searchingEnabled = YES;
-        self.layout = layout;
-    }
-
-    return self;
-}
-
 - (instancetype)initWithCollectionViewLayout:(UICollectionViewLayout *)layout context:(NSManagedObjectContext *)context searchingEnabled:(BOOL)searchingEnabled
 {
-    self = [super initWithCollectionViewLayout:layout];
+    self = [super init];
 
     if (self)
     {
@@ -54,42 +41,27 @@
     return self;
 }
 
-- (instancetype)initWithCoder:(NSCoder *)coder
+- (instancetype)initWithCollectionViewLayout:(UICollectionViewLayout *)layout context:(NSManagedObjectContext *)context
 {
-    self = [super initWithCoder:coder];
-
-    if (self)
-    {
-        self.searchingEnabled = YES;
-
-        self.layout = [[UICollectionViewFlowLayout alloc] init];
-    }
-    return self;
+    return [self initWithCollectionViewLayout:layout context:context searchingEnabled:YES];
 }
-
-//- (void)loadView
-//{
-//    self.collectionView = [[UICollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:self.layout];
-//    self.collectionView.delegate = self;
-//    self.collectionView.dataSource = self;
-//
-//    if (self.searchingEnabled)
-//    {
-//        self.edgesForExtendedLayout = UIRectEdgeNone;
-//
-//        self.searchBar = [[UISearchBar alloc] initWithFrame:CGRectMake(0, -44, CGRectGetWidth(self.collectionView.frame), 44)];
-//        self.searchBar.autoresizingMask = UIViewAutoresizingFlexibleWidth;
-//        self.searchBar.autocorrectionType = UITextAutocorrectionTypeNo;
-//        self.searchBar.delegate = self;
-//        [self.collectionView addSubview:self.searchBar];
-//    }
-//}
 
 - (void)viewDidLoad
 {
     [super viewDidLoad];
 
-    self.collectionView.collectionViewLayout = self.layout;
+    if (!self.collectionView)
+    {
+        self.collectionView = [[UICollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:self.layout];
+        self.collectionView.delegate = self;
+        self.collectionView.dataSource = self;
+        self.collectionView.collectionViewLayout = self.layout;
+        self.view = self.collectionView;
+    }
+    else
+    {
+        self.layout = self.collectionView.collectionViewLayout;
+    }
 
     if (self.searchingEnabled)
     {

--- a/Classes/ios/SQKFetchedCollectionViewController/SQKFetchedCollectionViewController.m
+++ b/Classes/ios/SQKFetchedCollectionViewController/SQKFetchedCollectionViewController.m
@@ -67,6 +67,24 @@
     return self;
 }
 
+- (void)loadView
+{
+    self.collectionView = [[UICollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:self.layout];
+    self.collectionView.delegate = self;
+    self.collectionView.dataSource = self;
+
+    if (self.searchingEnabled)
+    {
+        self.edgesForExtendedLayout = UIRectEdgeNone;
+
+        self.searchBar = [[UISearchBar alloc] initWithFrame:CGRectMake(0, -44, CGRectGetWidth(self.collectionView.frame), 44)];
+        self.searchBar.autoresizingMask = UIViewAutoresizingFlexibleWidth;
+        self.searchBar.autocorrectionType = UITextAutocorrectionTypeNo;
+        self.searchBar.delegate = self;
+        [self.collectionView addSubview:self.searchBar];
+    }
+}
+
 - (void)viewDidLoad
 {
     [super viewDidLoad];

--- a/Classes/ios/SQKFetchedCollectionViewController/SQKFetchedCollectionViewController.m
+++ b/Classes/ios/SQKFetchedCollectionViewController/SQKFetchedCollectionViewController.m
@@ -34,7 +34,7 @@
     {
         self.managedObjectContext = context;
         self.searchingEnabled = YES;
-        self.collectionView.collectionViewLayout = layout;
+        self.layout = layout;
     }
 
     return self;
@@ -48,7 +48,7 @@
     {
         self.managedObjectContext = context;
         self.searchingEnabled = searchingEnabled;
-        self.collectionView.collectionViewLayout = layout;
+        self.layout = layout;
     }
 
     return self;
@@ -61,6 +61,8 @@
     if (self)
     {
         self.searchingEnabled = YES;
+
+        self.layout = [[UICollectionViewFlowLayout alloc] init];
     }
     return self;
 }
@@ -68,6 +70,8 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
+
+    self.collectionView.collectionViewLayout = self.layout;
 
     if (self.searchingEnabled)
     {

--- a/Classes/ios/SQKFetchedCollectionViewController/SQKFetchedCollectionViewController.m
+++ b/Classes/ios/SQKFetchedCollectionViewController/SQKFetchedCollectionViewController.m
@@ -29,7 +29,7 @@
 
 - (instancetype)initWithCollectionViewLayout:(UICollectionViewLayout *)layout context:(NSManagedObjectContext *)context
 {
-    self = [super init];
+    self = [super initWithCollectionViewLayout:layout];
     if (self)
     {
         self.managedObjectContext = context;
@@ -42,7 +42,7 @@
 
 - (instancetype)initWithCollectionViewLayout:(UICollectionViewLayout *)layout context:(NSManagedObjectContext *)context searchingEnabled:(BOOL)searchingEnabled
 {
-    self = [super init];
+    self = [super initWithCollectionViewLayout:layout];
 
     if (self)
     {

--- a/Classes/ios/SQKFetchedCollectionViewController/SQKFetchedCollectionViewController.m
+++ b/Classes/ios/SQKFetchedCollectionViewController/SQKFetchedCollectionViewController.m
@@ -67,23 +67,23 @@
     return self;
 }
 
-- (void)loadView
-{
-    self.collectionView = [[UICollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:self.layout];
-    self.collectionView.delegate = self;
-    self.collectionView.dataSource = self;
-
-    if (self.searchingEnabled)
-    {
-        self.edgesForExtendedLayout = UIRectEdgeNone;
-
-        self.searchBar = [[UISearchBar alloc] initWithFrame:CGRectMake(0, -44, CGRectGetWidth(self.collectionView.frame), 44)];
-        self.searchBar.autoresizingMask = UIViewAutoresizingFlexibleWidth;
-        self.searchBar.autocorrectionType = UITextAutocorrectionTypeNo;
-        self.searchBar.delegate = self;
-        [self.collectionView addSubview:self.searchBar];
-    }
-}
+//- (void)loadView
+//{
+//    self.collectionView = [[UICollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:self.layout];
+//    self.collectionView.delegate = self;
+//    self.collectionView.dataSource = self;
+//
+//    if (self.searchingEnabled)
+//    {
+//        self.edgesForExtendedLayout = UIRectEdgeNone;
+//
+//        self.searchBar = [[UISearchBar alloc] initWithFrame:CGRectMake(0, -44, CGRectGetWidth(self.collectionView.frame), 44)];
+//        self.searchBar.autoresizingMask = UIViewAutoresizingFlexibleWidth;
+//        self.searchBar.autocorrectionType = UITextAutocorrectionTypeNo;
+//        self.searchBar.delegate = self;
+//        [self.collectionView addSubview:self.searchBar];
+//    }
+//}
 
 - (void)viewDidLoad
 {

--- a/Classes/ios/SQKFetchedCollectionViewController/SQKFetchedCollectionViewController.m
+++ b/Classes/ios/SQKFetchedCollectionViewController/SQKFetchedCollectionViewController.m
@@ -34,7 +34,7 @@
     {
         self.managedObjectContext = context;
         self.searchingEnabled = YES;
-        self.collectionViewLayout = layout;
+        self.collectionView.collectionViewLayout = layout;
     }
 
     return self;
@@ -48,7 +48,7 @@
     {
         self.managedObjectContext = context;
         self.searchingEnabled = searchingEnabled;
-        self.collectionViewLayout = layout;
+        self.collectionView.collectionViewLayout = layout;
     }
 
     return self;

--- a/Classes/ios/SQKFetchedTableViewController/SQKFetchedTableViewController.h
+++ b/Classes/ios/SQKFetchedTableViewController/SQKFetchedTableViewController.h
@@ -14,8 +14,9 @@
  *  This class provides a simpler way to replicate the often-used pattern of a searchable Core
  *  Data-backed table view. Must be used as a subclass.
  */
+IB_DESIGNABLE
 @interface SQKFetchedTableViewController
-    : UITableViewController <UISearchBarDelegate, UISearchDisplayDelegate, NSFetchedResultsControllerDelegate>
+    : UIViewController <UISearchBarDelegate, UISearchDisplayDelegate, NSFetchedResultsControllerDelegate>
 
 /**
  *  Initialises a Core Data-backed UITableViewController with a configured with a
@@ -55,7 +56,7 @@
  *  BOOL that when set to YES sets the table view controller's header view to a search view controller.
  *  Default is set to YES
  */
-@property (nonatomic, assign) BOOL searchingEnabled;
+@property (nonatomic, assign) IBInspectable BOOL searchingEnabled;
 
 /**
  *  Returns YES if the user is actively searching, i.e. the search bar has begun editing. Returns NO
@@ -69,7 +70,14 @@
  */
 @property (strong, nonatomic, readonly) UISearchDisplayController *searchController;
 
-@property (strong, nonatomic) UIView *emptyView;
+@property (strong, nonatomic) IBOutlet UIView *emptyView;
+
+/**
+ *  The base UITableView, for regular results.
+ */
+@property (strong, nonatomic) IBOutlet UITableView *tableView;
+
+@property (strong, nonatomic) UIRefreshControl *refreshControl;
 
 /**
  *  Returns the currently active UITableView (i.e. regular or search).

--- a/Project/Launch Screen.storyboard
+++ b/Project/Launch Screen.storyboard
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Llm-lL-Icb"/>
+                        <viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright © 2016 3Squared. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="obG-Y5-kRd">
+                                <rect key="frame" x="20" y="559" width="560" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SQKDataKit" textAlignment="center" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="GJd-Yh-RWb">
+                                <rect key="frame" x="20" y="180" width="560" height="43"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="36"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstAttribute="centerX" secondItem="obG-Y5-kRd" secondAttribute="centerX" id="5cz-MP-9tL"/>
+                            <constraint firstAttribute="centerX" secondItem="GJd-Yh-RWb" secondAttribute="centerX" id="Q3B-4B-g5h"/>
+                            <constraint firstItem="obG-Y5-kRd" firstAttribute="leading" secondItem="Ze5-6b-2t3" secondAttribute="leading" constant="20" symbolic="YES" id="SfN-ll-jLj"/>
+                            <constraint firstAttribute="bottom" secondItem="obG-Y5-kRd" secondAttribute="bottom" constant="20" id="Y44-ml-fuU"/>
+                            <constraint firstItem="GJd-Yh-RWb" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="bottom" multiplier="1/3" constant="1" id="moa-c2-u7t"/>
+                            <constraint firstItem="GJd-Yh-RWb" firstAttribute="leading" secondItem="Ze5-6b-2t3" secondAttribute="leading" constant="20" symbolic="YES" id="x7j-FC-K8j"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/Project/Podfile.lock
+++ b/Project/Podfile.lock
@@ -1,19 +1,19 @@
 PODS:
   - OCMock (2.2.4)
-  - SQKDataKit/ContextManager (0.6.0):
+  - SQKDataKit/ContextManager (1.1.1):
     - SQKDataKit/Core
-  - SQKDataKit/Core (0.6.0)
-  - SQKDataKit/CoreDataOperation (0.6.0):
+  - SQKDataKit/Core (1.1.1)
+  - SQKDataKit/CoreDataOperation (1.1.1):
     - SQKDataKit/ContextManager
     - SQKDataKit/Core
     - SQKDataKit/ManagedObjectExtensions
-  - SQKDataKit/FetchedCollectionViewController (0.6.0):
+  - SQKDataKit/FetchedCollectionViewController (1.1.1):
     - SQKDataKit/Core
-  - SQKDataKit/FetchedTableViewController (0.6.0):
+  - SQKDataKit/FetchedTableViewController (1.1.1):
     - SQKDataKit/Core
-  - SQKDataKit/ManagedObjectController (0.6.0):
+  - SQKDataKit/ManagedObjectController (1.1.1):
     - SQKDataKit/Core
-  - SQKDataKit/ManagedObjectExtensions (0.6.0):
+  - SQKDataKit/ManagedObjectExtensions (1.1.1):
     - SQKDataKit/Core
 
 DEPENDENCIES:
@@ -31,6 +31,6 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   OCMock: a6a7dc0e3997fb9f35d99f72528698ebf60d64f2
-  SQKDataKit: c3e7196e712ed7ab2997b64ff11bdedb5b0eaf51
+  SQKDataKit: b906fc7ca22c35a3b54f487e218d1544a0509169
 
 COCOAPODS: 0.39.0

--- a/Project/SQKDataKit.xcodeproj/project.pbxproj
+++ b/Project/SQKDataKit.xcodeproj/project.pbxproj
@@ -43,6 +43,9 @@
 		AFFC25DF40274C52A419927E /* libPods-SQKDataKit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B2868235566F44D78765833F /* libPods-SQKDataKit.a */; };
 		C8CFF472097F4E5BBA949BDB /* libPods-SQKDataKitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4AB52E80206042BCB848D249 /* libPods-SQKDataKitTests.a */; };
 		CB40EDD41A65633900181627 /* SQKAlternateCommitsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = CB40EDD31A65633900181627 /* SQKAlternateCommitsViewController.m */; };
+		CBFC91CB1CD206DB00444C39 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CBFC91CA1CD206DB00444C39 /* Launch Screen.storyboard */; };
+		CBFC91CD1CD2076500444C39 /* Storyboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CBFC91CC1CD2076500444C39 /* Storyboard.storyboard */; };
+		CBFC91D01CD20C9100444C39 /* SQKStoryboardCommitsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = CBFC91CF1CD20C9100444C39 /* SQKStoryboardCommitsViewController.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -115,6 +118,10 @@
 		B2868235566F44D78765833F /* libPods-SQKDataKit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SQKDataKit.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CB40EDD21A65633900181627 /* SQKAlternateCommitsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SQKAlternateCommitsViewController.h; sourceTree = "<group>"; };
 		CB40EDD31A65633900181627 /* SQKAlternateCommitsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SQKAlternateCommitsViewController.m; sourceTree = "<group>"; };
+		CBFC91CA1CD206DB00444C39 /* Launch Screen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = "Launch Screen.storyboard"; path = "../Launch Screen.storyboard"; sourceTree = "<group>"; };
+		CBFC91CC1CD2076500444C39 /* Storyboard.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Storyboard.storyboard; sourceTree = "<group>"; };
+		CBFC91CE1CD20C9100444C39 /* SQKStoryboardCommitsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SQKStoryboardCommitsViewController.h; sourceTree = "<group>"; };
+		CBFC91CF1CD20C9100444C39 /* SQKStoryboardCommitsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SQKStoryboardCommitsViewController.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -201,6 +208,7 @@
 				A3DC7C9A1868731100C45DB0 /* SQKJSONLoader.m */,
 				CB40EDD21A65633900181627 /* SQKAlternateCommitsViewController.h */,
 				CB40EDD31A65633900181627 /* SQKAlternateCommitsViewController.m */,
+				CBFC91D11CD2119C00444C39 /* Storyboard Example */,
 			);
 			name = Controller;
 			sourceTree = "<group>";
@@ -266,6 +274,7 @@
 		A34BF3A1184F41D300F2E3B4 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				CBFC91CA1CD206DB00444C39 /* Launch Screen.storyboard */,
 				A34BF3A2184F41D300F2E3B4 /* SQKDataKit-Info.plist */,
 				A34BF3A3184F41D300F2E3B4 /* InfoPlist.strings */,
 				A34BF3A6184F41D300F2E3B4 /* main.m */,
@@ -312,6 +321,16 @@
 				A37F4E431B29A95A0087D344 /* SQKErroringManagedObjectContext.m */,
 			);
 			name = Mocks;
+			sourceTree = "<group>";
+		};
+		CBFC91D11CD2119C00444C39 /* Storyboard Example */ = {
+			isa = PBXGroup;
+			children = (
+				CBFC91CE1CD20C9100444C39 /* SQKStoryboardCommitsViewController.h */,
+				CBFC91CF1CD20C9100444C39 /* SQKStoryboardCommitsViewController.m */,
+				CBFC91CC1CD2076500444C39 /* Storyboard.storyboard */,
+			);
+			name = "Storyboard Example";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -399,7 +418,9 @@
 			files = (
 				A34BF3B6184F41D400F2E3B4 /* Images.xcassets in Resources */,
 				A3DC7CA018687E2E00C45DB0 /* data_1500.json in Resources */,
+				CBFC91CB1CD206DB00444C39 /* Launch Screen.storyboard in Resources */,
 				A34BF3A5184F41D300F2E3B4 /* InfoPlist.strings in Resources */,
+				CBFC91CD1CD2076500444C39 /* Storyboard.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -513,6 +534,7 @@
 			files = (
 				2289468119BF27F900289506 /* User.m in Sources */,
 				4AD576CA1A5DA58C00EA277A /* SQKCommitsCollectionViewController.m in Sources */,
+				CBFC91D01CD20C9100444C39 /* SQKStoryboardCommitsViewController.m in Sources */,
 				A3F70A8D1859D80C00C0A389 /* SQKCommitCell.m in Sources */,
 				A3C66D06185A20CE007AE9B5 /* NaiveImportOperation.m in Sources */,
 				4AD576CD1A5DAB2D00EA277A /* SQKCommitItemCell.m in Sources */,
@@ -652,7 +674,6 @@
 			baseConfigurationReference = 13CD1E4097C4550C3CDE9FF2 /* Pods-SQKDataKit.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "SQKDataKit/SQKDataKit-Prefix.pch";
@@ -671,7 +692,6 @@
 			baseConfigurationReference = 36C20EE916F9895AE5B1716D /* Pods-SQKDataKit.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "SQKDataKit/SQKDataKit-Prefix.pch";

--- a/Project/SQKDataKit.xcodeproj/project.pbxproj
+++ b/Project/SQKDataKit.xcodeproj/project.pbxproj
@@ -46,6 +46,9 @@
 		CBFC91CB1CD206DB00444C39 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CBFC91CA1CD206DB00444C39 /* Launch Screen.storyboard */; };
 		CBFC91CD1CD2076500444C39 /* Storyboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CBFC91CC1CD2076500444C39 /* Storyboard.storyboard */; };
 		CBFC91D01CD20C9100444C39 /* SQKStoryboardCommitsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = CBFC91CF1CD20C9100444C39 /* SQKStoryboardCommitsViewController.m */; };
+		CBFC91D41CD21CD400444C39 /* SQKStoryboardCommitsCollectionViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = CBFC91D31CD21CD400444C39 /* SQKStoryboardCommitsCollectionViewController.m */; };
+		CBFC91D71CD21F2E00444C39 /* SQKStoryboardCollectionViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = CBFC91D61CD21F2E00444C39 /* SQKStoryboardCollectionViewCell.m */; };
+		CBFC91DA1CD221C900444C39 /* SQKStoryboardCollectionHeaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = CBFC91D91CD221C900444C39 /* SQKStoryboardCollectionHeaderView.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -122,6 +125,12 @@
 		CBFC91CC1CD2076500444C39 /* Storyboard.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Storyboard.storyboard; sourceTree = "<group>"; };
 		CBFC91CE1CD20C9100444C39 /* SQKStoryboardCommitsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SQKStoryboardCommitsViewController.h; sourceTree = "<group>"; };
 		CBFC91CF1CD20C9100444C39 /* SQKStoryboardCommitsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SQKStoryboardCommitsViewController.m; sourceTree = "<group>"; };
+		CBFC91D21CD21CD400444C39 /* SQKStoryboardCommitsCollectionViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SQKStoryboardCommitsCollectionViewController.h; sourceTree = "<group>"; };
+		CBFC91D31CD21CD400444C39 /* SQKStoryboardCommitsCollectionViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SQKStoryboardCommitsCollectionViewController.m; sourceTree = "<group>"; };
+		CBFC91D51CD21F2E00444C39 /* SQKStoryboardCollectionViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SQKStoryboardCollectionViewCell.h; sourceTree = "<group>"; };
+		CBFC91D61CD21F2E00444C39 /* SQKStoryboardCollectionViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SQKStoryboardCollectionViewCell.m; sourceTree = "<group>"; };
+		CBFC91D81CD221C900444C39 /* SQKStoryboardCollectionHeaderView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SQKStoryboardCollectionHeaderView.h; sourceTree = "<group>"; };
+		CBFC91D91CD221C900444C39 /* SQKStoryboardCollectionHeaderView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SQKStoryboardCollectionHeaderView.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -328,6 +337,12 @@
 			children = (
 				CBFC91CE1CD20C9100444C39 /* SQKStoryboardCommitsViewController.h */,
 				CBFC91CF1CD20C9100444C39 /* SQKStoryboardCommitsViewController.m */,
+				CBFC91D21CD21CD400444C39 /* SQKStoryboardCommitsCollectionViewController.h */,
+				CBFC91D31CD21CD400444C39 /* SQKStoryboardCommitsCollectionViewController.m */,
+				CBFC91D51CD21F2E00444C39 /* SQKStoryboardCollectionViewCell.h */,
+				CBFC91D61CD21F2E00444C39 /* SQKStoryboardCollectionViewCell.m */,
+				CBFC91D81CD221C900444C39 /* SQKStoryboardCollectionHeaderView.h */,
+				CBFC91D91CD221C900444C39 /* SQKStoryboardCollectionHeaderView.m */,
 				CBFC91CC1CD2076500444C39 /* Storyboard.storyboard */,
 			);
 			name = "Storyboard Example";
@@ -537,11 +552,14 @@
 				CBFC91D01CD20C9100444C39 /* SQKStoryboardCommitsViewController.m in Sources */,
 				A3F70A8D1859D80C00C0A389 /* SQKCommitCell.m in Sources */,
 				A3C66D06185A20CE007AE9B5 /* NaiveImportOperation.m in Sources */,
+				CBFC91D71CD21F2E00444C39 /* SQKStoryboardCollectionViewCell.m in Sources */,
 				4AD576CD1A5DAB2D00EA277A /* SQKCommitItemCell.m in Sources */,
 				CB40EDD41A65633900181627 /* SQKAlternateCommitsViewController.m in Sources */,
+				CBFC91D41CD21CD400444C39 /* SQKStoryboardCommitsCollectionViewController.m in Sources */,
 				A34BF3B4184F41D400F2E3B4 /* SQKCommitsViewController.m in Sources */,
 				22780673196AB3DE00F8DED4 /* SQKCommitDetailViewController.m in Sources */,
 				A31AB0E71857769D00B240AB /* Commit.m in Sources */,
+				CBFC91DA1CD221C900444C39 /* SQKStoryboardCollectionHeaderView.m in Sources */,
 				A328BAC71850986A00267F2E /* SQKDataKitModel.xcdatamodeld in Sources */,
 				A34BF3AB184F41D300F2E3B4 /* SQKAppDelegate.m in Sources */,
 				A31AB0EC185776AE00B240AB /* OptimisedImportOperation.m in Sources */,

--- a/Project/SQKDataKit.xcworkspace/xcshareddata/SQKDataKit.xcscmblueprint
+++ b/Project/SQKDataKit.xcworkspace/xcshareddata/SQKDataKit.xcscmblueprint
@@ -1,0 +1,30 @@
+{
+  "DVTSourceControlWorkspaceBlueprintPrimaryRemoteRepositoryKey" : "D3BB94670B6CEF9A8A4C6FAA1DBE0D5025BFEF3A",
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyRepositoryLocationsKey" : {
+
+  },
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyStatesKey" : {
+    "D3BB94670B6CEF9A8A4C6FAA1DBE0D5025BFEF3A" : 0,
+    "EE10C43E6C8BE2BC68765330A89116EDBFE39DB3" : 0
+  },
+  "DVTSourceControlWorkspaceBlueprintIdentifierKey" : "21432975-63D2-4331-A055-18E9629DE108",
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey" : {
+    "D3BB94670B6CEF9A8A4C6FAA1DBE0D5025BFEF3A" : "SQKDataKit\/",
+    "EE10C43E6C8BE2BC68765330A89116EDBFE39DB3" : ".."
+  },
+  "DVTSourceControlWorkspaceBlueprintNameKey" : "SQKDataKit",
+  "DVTSourceControlWorkspaceBlueprintVersion" : 204,
+  "DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey" : "Project\/SQKDataKit.xcworkspace",
+  "DVTSourceControlWorkspaceBlueprintRemoteRepositoriesKey" : [
+    {
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "github.com:3squared\/SQKDataKit.git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "D3BB94670B6CEF9A8A4C6FAA1DBE0D5025BFEF3A"
+    },
+    {
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "git.3squared.com:sir-robert-mcalpine\/Site-Companion-iOS.git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "EE10C43E6C8BE2BC68765330A89116EDBFE39DB3"
+    }
+  ]
+}

--- a/Project/SQKDataKit/SQKAppDelegate.h
+++ b/Project/SQKDataKit/SQKAppDelegate.h
@@ -13,4 +13,6 @@
 
 @property (nonatomic, strong) UIWindow *window;
 
+- (SQKContextManager *)contextManager;
+
 @end

--- a/Project/SQKDataKit/SQKAppDelegate.m
+++ b/Project/SQKDataKit/SQKAppDelegate.m
@@ -58,10 +58,11 @@ static BOOL isRunningTests(void)
         [[UINavigationController alloc] initWithRootViewController:altCommitsViewController];
 
     UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Storyboard" bundle:nil];
-    UIViewController *storyboardViewController = [storyboard instantiateInitialViewController];
+    UIViewController *storyboardTableViewController = [storyboard instantiateViewControllerWithIdentifier:@"Table"];
+    UIViewController *storyboardCollectionViewController = [storyboard instantiateViewControllerWithIdentifier:@"Collection"];
 
     UITabBarController *tabBarController = [[UITabBarController alloc] init];
-    tabBarController.viewControllers = @[ metricsNavController, commitsNavController, altCommitsNavController, commitsCollectionNavController, storyboardViewController ];
+    tabBarController.viewControllers = @[ metricsNavController, commitsNavController, altCommitsNavController, commitsCollectionNavController, storyboardTableViewController, storyboardCollectionViewController ];
 
     self.window.rootViewController = tabBarController;
     [self.window makeKeyAndVisible];

--- a/Project/SQKDataKit/SQKAppDelegate.m
+++ b/Project/SQKDataKit/SQKAppDelegate.m
@@ -6,12 +6,12 @@
 //  Copyright (c) 2013 3Squared. All rights reserved.
 //
 
-#import "SQKAppDelegate.h"
-#import "SQKCommitsViewController.h"
-#import "SQKCommitsCollectionViewController.h"
-#import "SQKCollectionViewFlowLayout.h"
-#import "SQKMetricsViewController.h"
 #import "SQKAlternateCommitsViewController.h"
+#import "SQKAppDelegate.h"
+#import "SQKCollectionViewFlowLayout.h"
+#import "SQKCommitsCollectionViewController.h"
+#import "SQKCommitsViewController.h"
+#import "SQKMetricsViewController.h"
 #import <SQKDataKit/SQKContextManager.h>
 
 @interface SQKAppDelegate ()
@@ -57,8 +57,11 @@ static BOOL isRunningTests(void)
     UINavigationController *altCommitsNavController =
         [[UINavigationController alloc] initWithRootViewController:altCommitsViewController];
 
+    UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Storyboard" bundle:nil];
+    UIViewController *storyboardViewController = [storyboard instantiateInitialViewController];
+
     UITabBarController *tabBarController = [[UITabBarController alloc] init];
-    tabBarController.viewControllers = @[ metricsNavController, commitsNavController, altCommitsNavController, commitsCollectionNavController ];
+    tabBarController.viewControllers = @[ metricsNavController, commitsNavController, altCommitsNavController, commitsCollectionNavController, storyboardViewController ];
 
     self.window.rootViewController = tabBarController;
     [self.window makeKeyAndVisible];

--- a/Project/SQKDataKit/SQKDataKit-Info.plist
+++ b/Project/SQKDataKit/SQKDataKit-Info.plist
@@ -24,6 +24,8 @@
 	<string>1.1.1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>Launch Screen</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>

--- a/Project/SQKDataKit/SQKStoryboardCollectionHeaderView.h
+++ b/Project/SQKDataKit/SQKStoryboardCollectionHeaderView.h
@@ -1,0 +1,13 @@
+//
+//  SQKStoryboardCollectionHeaderView.h
+//  SQKDataKit
+//
+//  Created by Sam Oakley on 28/04/2016.
+//  Copyright © 2016 3Squared. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface SQKStoryboardCollectionHeaderView : UICollectionReusableView
+@property (weak, nonatomic) IBOutlet UILabel *textLabel;
+@end

--- a/Project/SQKDataKit/SQKStoryboardCollectionHeaderView.m
+++ b/Project/SQKDataKit/SQKStoryboardCollectionHeaderView.m
@@ -1,0 +1,13 @@
+//
+//  SQKStoryboardCollectionHeaderView.m
+//  SQKDataKit
+//
+//  Created by Sam Oakley on 28/04/2016.
+//  Copyright © 2016 3Squared. All rights reserved.
+//
+
+#import "SQKStoryboardCollectionHeaderView.h"
+
+@implementation SQKStoryboardCollectionHeaderView
+
+@end

--- a/Project/SQKDataKit/SQKStoryboardCollectionViewCell.h
+++ b/Project/SQKDataKit/SQKStoryboardCollectionViewCell.h
@@ -1,0 +1,13 @@
+//
+//  SQKStoryboardCollectionViewCell.h
+//  SQKDataKit
+//
+//  Created by Sam Oakley on 28/04/2016.
+//  Copyright © 2016 3Squared. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface SQKStoryboardCollectionViewCell : UICollectionViewCell
+@property (weak, nonatomic) IBOutlet UILabel *textLabel;
+@end

--- a/Project/SQKDataKit/SQKStoryboardCollectionViewCell.m
+++ b/Project/SQKDataKit/SQKStoryboardCollectionViewCell.m
@@ -1,0 +1,13 @@
+//
+//  SQKStoryboardCollectionViewCell.m
+//  SQKDataKit
+//
+//  Created by Sam Oakley on 28/04/2016.
+//  Copyright © 2016 3Squared. All rights reserved.
+//
+
+#import "SQKStoryboardCollectionViewCell.h"
+
+@implementation SQKStoryboardCollectionViewCell
+
+@end

--- a/Project/SQKDataKit/SQKStoryboardCommitsCollectionViewController.h
+++ b/Project/SQKDataKit/SQKStoryboardCommitsCollectionViewController.h
@@ -1,0 +1,13 @@
+//
+//  SQKStoryboardCommitsCollectionViewController.h
+//  SQKDataKit
+//
+//  Created by Sam Oakley on 28/04/2016.
+//  Copyright © 2016 3Squared. All rights reserved.
+//
+
+#import <SQKDataKit/SQKFetchedCollectionViewController.h>
+
+@interface SQKStoryboardCommitsCollectionViewController : SQKFetchedCollectionViewController
+
+@end

--- a/Project/SQKDataKit/SQKStoryboardCommitsCollectionViewController.m
+++ b/Project/SQKDataKit/SQKStoryboardCommitsCollectionViewController.m
@@ -1,0 +1,103 @@
+//
+//  SQKStoryboardCommitsCollectionViewController.m
+//  SQKDataKit
+//
+//  Created by Sam Oakley on 28/04/2016.
+//  Copyright © 2016 3Squared. All rights reserved.
+//
+
+#import "Commit.h"
+#import "SQKAppDelegate.h"
+#import "SQKStoryboardCollectionHeaderView.h"
+#import "SQKStoryboardCollectionViewCell.h"
+#import "SQKStoryboardCommitsCollectionViewController.h"
+#import <SQKDataKit/NSManagedObject+SQKAdditions.h>
+#import <SQKDataKit/SQKContextManager.h>
+#import <SQKDataKit/SQKFetchedCollectionViewController.h>
+
+@interface SQKStoryboardCommitsCollectionViewController ()
+
+@end
+
+@implementation SQKStoryboardCommitsCollectionViewController
+
+#pragma mark -
+
+- (NSManagedObjectContext *)managedObjectContext
+{
+    return [((SQKAppDelegate *)[[UIApplication sharedApplication] delegate]).contextManager mainContext];
+}
+
+- (NSFetchRequest *)fetchRequestForSearch:(NSString *)searchString
+{
+    NSFetchRequest *request = [Commit sqk_fetchRequest];
+    request.sortDescriptors = @[ [NSSortDescriptor sortDescriptorWithKey:@"authorName" ascending:YES] ];
+
+    NSPredicate *filterPredicate = nil;
+    if (searchString.length)
+    {
+        filterPredicate = [NSPredicate predicateWithFormat:@"authorName CONTAINS[cd] %@", searchString];
+    }
+
+    [request setPredicate:filterPredicate];
+
+    return request;
+}
+
+- (void)fetchedResultsController:(NSFetchedResultsController *)fetchedResultsController configureItemCell:(UICollectionViewCell *)theItemCell atIndexPath:(NSIndexPath *)indexPath
+{
+    Commit *commit = [fetchedResultsController objectAtIndexPath:indexPath];
+    SQKStoryboardCollectionViewCell *cell = (SQKStoryboardCollectionViewCell *)theItemCell;
+    cell.textLabel.text = [[self firstCharactersForString:commit.authorName] uppercaseString];
+}
+
+- (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath
+{
+    UICollectionViewCell *itemCell = [collectionView dequeueReusableCellWithReuseIdentifier:@"Cell" forIndexPath:indexPath];
+    return itemCell;
+}
+
+- (void)collectionView:(UICollectionView *)collectionView willDisplayCell:(UICollectionViewCell *)cell forItemAtIndexPath:(NSIndexPath *)indexPath
+{
+    [self fetchedResultsController:self.fetchedResultsController
+                 configureItemCell:cell
+                       atIndexPath:indexPath];
+}
+
+- (NSString *)sectionKeyPathForSearchableFetchedResultsController:(SQKFetchedCollectionViewController *)controller
+{
+    return @"authorName";
+}
+
+- (UIEdgeInsets)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout insetForSectionAtIndex:(NSInteger)section
+{
+    return UIEdgeInsetsMake(10, 26, 10, 26);
+}
+
+- (UICollectionReusableView *)collectionView:(UICollectionView *)collectionView viewForSupplementaryElementOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath
+{
+    if (kind == UICollectionElementKindSectionHeader)
+    {
+        SQKStoryboardCollectionHeaderView *view = (SQKStoryboardCollectionHeaderView *)[self.collectionView dequeueReusableSupplementaryViewOfKind:kind withReuseIdentifier:@"Header" forIndexPath:indexPath];
+        id<NSFetchedResultsSectionInfo> section = self.fetchedResultsController.sections[indexPath.section];
+        view.textLabel.text = [section name];
+        return view;
+    }
+    return nil;
+}
+
+- (NSString *)firstCharactersForString:(NSString *)string
+{
+    NSMutableString *firstCharacters = [NSMutableString string];
+
+    NSArray *words = [string componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+
+    [words enumerateObjectsUsingBlock:^(NSString *word, NSUInteger idx, BOOL *stop) {
+      NSString *firstLetter = [word substringToIndex:1];
+      [firstCharacters appendString:firstLetter];
+    }];
+
+    return firstCharacters;
+}
+
+@end

--- a/Project/SQKDataKit/SQKStoryboardCommitsViewController.h
+++ b/Project/SQKDataKit/SQKStoryboardCommitsViewController.h
@@ -1,0 +1,14 @@
+//
+//  SQKStoryboardCommitsViewController.h
+//  SQKDataKit
+//
+//  Created by Sam Oakley on 28/04/2016.
+//  Copyright © 2016 3Squared. All rights reserved.
+//
+
+#import <SQKDataKit/SQKFetchedTableViewController.h>
+#import <UIKit/UIKit.h>
+
+@interface SQKStoryboardCommitsViewController : SQKFetchedTableViewController
+
+@end

--- a/Project/SQKDataKit/SQKStoryboardCommitsViewController.m
+++ b/Project/SQKDataKit/SQKStoryboardCommitsViewController.m
@@ -1,0 +1,59 @@
+//
+//  SQKStoryboardCommitsViewController.m
+//  SQKDataKit
+//
+//  Created by Sam Oakley on 28/04/2016.
+//  Copyright © 2016 3Squared. All rights reserved.
+//
+
+#import "Commit.h"
+#import "SQKAppDelegate.h"
+#import "SQKStoryboardCommitsViewController.h"
+#import <SQKDataKit/NSManagedObject+SQKAdditions.h>
+#import <SQKDataKit/SQKContextManager.h>
+
+@interface SQKStoryboardCommitsViewController ()
+
+@end
+
+@implementation SQKStoryboardCommitsViewController
+
+- (NSManagedObjectContext *)managedObjectContext
+{
+    return [((SQKAppDelegate *)[[UIApplication sharedApplication] delegate]).contextManager mainContext];
+}
+
+#pragma mark -
+
+- (NSFetchRequest *)fetchRequestForSearch:(NSString *)searchString
+{
+    NSFetchRequest *request = [Commit sqk_fetchRequest];
+    request.sortDescriptors = @[ [NSSortDescriptor sortDescriptorWithKey:@"date" ascending:NO] ];
+
+    NSPredicate *filterPredicate = nil;
+    if (searchString.length)
+    {
+        filterPredicate = [NSPredicate predicateWithFormat:@"authorName CONTAINS[cd] %@", searchString];
+    }
+
+    [request setPredicate:filterPredicate];
+
+    return request;
+}
+
+- (void)fetchedResultsController:(NSFetchedResultsController *)fetchedResultsController
+                   configureCell:(UITableViewCell *)cell
+                     atIndexPath:(NSIndexPath *)indexPath
+{
+    Commit *commit = [fetchedResultsController objectAtIndexPath:indexPath];
+    cell.textLabel.text = commit.message;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
+{
+    UITableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:@"Cell" forIndexPath:indexPath];
+    [self fetchedResultsController:[self activeFetchedResultsController] configureCell:cell atIndexPath:indexPath];
+    return cell;
+}
+
+@end

--- a/Project/SQKDataKit/Storyboard.storyboard
+++ b/Project/SQKDataKit/Storyboard.storyboard
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="5qJ-PB-hV0">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+    </dependencies>
+    <scenes>
+        <!--Storyboard-->
+        <scene sceneID="0uj-8D-233">
+            <objects>
+                <viewController automaticallyAdjustsScrollViewInsets="NO" id="xRD-Il-yQH" customClass="SQKStoryboardCommitsViewController" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="YKM-ma-BXd"/>
+                        <viewControllerLayoutGuide type="bottom" id="62h-S5-0Qe"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Xqg-iG-ler">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Gux-IA-7JU">
+                                <rect key="frame" x="0.0" y="64" width="600" height="536"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <view key="tableFooterView" contentMode="scaleToFill" id="JO4-6N-tiu">
+                                    <rect key="frame" x="0.0" y="72" width="600" height="0.0"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                </view>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="Cell" textLabel="DtF-vJ-QeO" style="IBUITableViewCellStyleDefault" id="fCd-0p-MG3">
+                                        <rect key="frame" x="0.0" y="28" width="600" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="fCd-0p-MG3" id="U4h-y9-VTa">
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="DtF-vJ-QeO">
+                                                    <rect key="frame" x="15" y="0.0" width="570" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </prototypes>
+                                <connections>
+                                    <outlet property="dataSource" destination="xRD-Il-yQH" id="Gt9-f1-Nya"/>
+                                    <outlet property="delegate" destination="xRD-Il-yQH" id="WYW-Fk-jvb"/>
+                                </connections>
+                            </tableView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Nothing to show" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2nX-rw-Rbn">
+                                <rect key="frame" x="219" y="287" width="161.5" height="26.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="22"/>
+                                <color key="textColor" red="0.82352942230000004" green="0.83137255909999996" blue="0.84313726430000002" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstAttribute="trailing" secondItem="Gux-IA-7JU" secondAttribute="trailing" id="0ZK-ZF-97s"/>
+                            <constraint firstItem="62h-S5-0Qe" firstAttribute="top" secondItem="Gux-IA-7JU" secondAttribute="bottom" id="79q-Os-bla"/>
+                            <constraint firstItem="Gux-IA-7JU" firstAttribute="top" secondItem="YKM-ma-BXd" secondAttribute="bottom" id="7dk-Lq-pVE"/>
+                            <constraint firstItem="Gux-IA-7JU" firstAttribute="leading" secondItem="Xqg-iG-ler" secondAttribute="leading" id="8hd-I4-e9B"/>
+                            <constraint firstItem="2nX-rw-Rbn" firstAttribute="centerX" secondItem="Xqg-iG-ler" secondAttribute="centerX" id="hG7-E1-ote"/>
+                            <constraint firstItem="2nX-rw-Rbn" firstAttribute="centerY" secondItem="Xqg-iG-ler" secondAttribute="centerY" id="ui8-48-3j5"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" title="Storyboard" id="mpr-c7-PrT"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="boolean" keyPath="searchingEnabled" value="YES"/>
+                    </userDefinedRuntimeAttributes>
+                    <connections>
+                        <outlet property="emptyView" destination="2nX-rw-Rbn" id="FVS-CP-7Na"/>
+                        <outlet property="tableView" destination="Gux-IA-7JU" id="Uwe-AW-Tmr"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="L7L-hQ-cNO" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1151" y="520"/>
+        </scene>
+        <!--Storyboard-->
+        <scene sceneID="ueL-lS-zvs">
+            <objects>
+                <navigationController title="Storyboard" automaticallyAdjustsScrollViewInsets="NO" id="5qJ-PB-hV0" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="TSz-oj-MJe">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="xRD-Il-yQH" kind="relationship" relationship="rootViewController" id="deL-jO-KYo"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="tfL-mr-WTg" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="339" y="520"/>
+        </scene>
+    </scenes>
+</document>

--- a/Project/SQKDataKit/Storyboard.storyboard
+++ b/Project/SQKDataKit/Storyboard.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="5qJ-PB-hV0">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
         <!--Storyboard-->
@@ -79,10 +80,10 @@
             </objects>
             <point key="canvasLocation" x="1151" y="520"/>
         </scene>
-        <!--Storyboard-->
+        <!--Storyboard Table-->
         <scene sceneID="ueL-lS-zvs">
             <objects>
-                <navigationController title="Storyboard" automaticallyAdjustsScrollViewInsets="NO" id="5qJ-PB-hV0" sceneMemberID="viewController">
+                <navigationController storyboardIdentifier="Table" title="Storyboard Table" automaticallyAdjustsScrollViewInsets="NO" useStoryboardIdentifierAsRestorationIdentifier="YES" id="5qJ-PB-hV0" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="TSz-oj-MJe">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
@@ -96,6 +97,122 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="tfL-mr-WTg" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="339" y="520"/>
+        </scene>
+        <!--Storyboard Commits Collection View Controller-->
+        <scene sceneID="zya-W1-d0F">
+            <objects>
+                <viewController automaticallyAdjustsScrollViewInsets="NO" id="kTz-5R-0P4" customClass="SQKStoryboardCommitsCollectionViewController" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Xyj-ss-2Fb"/>
+                        <viewControllerLayoutGuide type="bottom" id="hQc-MJ-jkL"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="ArP-rP-ll4">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="hR7-39-cpZ">
+                                <rect key="frame" x="0.0" y="64" width="600" height="536"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <inset key="scrollIndicatorInsets" minX="26" minY="10" maxX="16" maxY="10"/>
+                                <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="ZMo-p5-GnG">
+                                    <size key="itemSize" width="120" height="120"/>
+                                    <size key="headerReferenceSize" width="50" height="50"/>
+                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                </collectionViewFlowLayout>
+                                <cells>
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="Cell" id="pNG-H4-Acw" customClass="SQKStoryboardCollectionViewCell">
+                                        <rect key="frame" x="0.0" y="50" width="120" height="120"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
+                                            <rect key="frame" x="0.0" y="0.0" width="120" height="120"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="AV" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qf6-cK-BE3">
+                                                    <rect key="frame" x="8" y="8" width="104" height="104"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="35"/>
+                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                        </view>
+                                        <constraints>
+                                            <constraint firstAttribute="trailingMargin" secondItem="Qf6-cK-BE3" secondAttribute="trailing" id="H7u-K5-W4m"/>
+                                            <constraint firstAttribute="bottomMargin" secondItem="Qf6-cK-BE3" secondAttribute="bottom" id="KvC-xy-GXp"/>
+                                            <constraint firstItem="Qf6-cK-BE3" firstAttribute="leading" secondItem="pNG-H4-Acw" secondAttribute="leadingMargin" id="hnu-UD-ZP9"/>
+                                            <constraint firstItem="Qf6-cK-BE3" firstAttribute="top" secondItem="pNG-H4-Acw" secondAttribute="topMargin" id="wM9-Ob-QpA"/>
+                                        </constraints>
+                                        <connections>
+                                            <outlet property="textLabel" destination="Qf6-cK-BE3" id="ayN-1T-6uQ"/>
+                                        </connections>
+                                    </collectionViewCell>
+                                </cells>
+                                <collectionReusableView key="sectionHeaderView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="Header" id="ktz-IB-jWq" customClass="SQKStoryboardCollectionHeaderView">
+                                    <rect key="frame" x="0.0" y="0.0" width="600" height="50"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SmS-EW-08V">
+                                            <rect key="frame" x="8" y="8" width="584" height="34"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstAttribute="bottomMargin" secondItem="SmS-EW-08V" secondAttribute="bottom" id="0QC-km-RGM"/>
+                                        <constraint firstItem="SmS-EW-08V" firstAttribute="leading" secondItem="ktz-IB-jWq" secondAttribute="leadingMargin" id="ImQ-c5-Zv3"/>
+                                        <constraint firstItem="SmS-EW-08V" firstAttribute="top" secondItem="ktz-IB-jWq" secondAttribute="topMargin" id="l2a-zZ-7dG"/>
+                                        <constraint firstAttribute="trailingMargin" secondItem="SmS-EW-08V" secondAttribute="trailing" id="uDS-Vu-rUj"/>
+                                    </constraints>
+                                    <connections>
+                                        <outlet property="textLabel" destination="SmS-EW-08V" id="CtZ-Ap-6DG"/>
+                                    </connections>
+                                </collectionReusableView>
+                                <connections>
+                                    <outlet property="dataSource" destination="kTz-5R-0P4" id="mkc-J2-FCC"/>
+                                    <outlet property="delegate" destination="kTz-5R-0P4" id="Q7r-PZ-FqP"/>
+                                </connections>
+                            </collectionView>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstAttribute="trailing" secondItem="hR7-39-cpZ" secondAttribute="trailing" id="972-0A-ifN"/>
+                            <constraint firstItem="hR7-39-cpZ" firstAttribute="leading" secondItem="ArP-rP-ll4" secondAttribute="leading" id="XSh-fs-pwB"/>
+                            <constraint firstItem="hR7-39-cpZ" firstAttribute="top" secondItem="Xyj-ss-2Fb" secondAttribute="bottom" id="fSK-yg-93D"/>
+                            <constraint firstItem="hQc-MJ-jkL" firstAttribute="top" secondItem="hR7-39-cpZ" secondAttribute="bottom" id="rgk-O1-JLh"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="eJo-EP-FLY"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="boolean" keyPath="searchingEnabled" value="YES"/>
+                        <userDefinedRuntimeAttribute type="boolean" keyPath="showsSectionsWhenSearching" value="YES"/>
+                    </userDefinedRuntimeAttributes>
+                    <connections>
+                        <outlet property="collectionView" destination="hR7-39-cpZ" id="WJf-kL-xjO"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="IfT-pv-l3p" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1151" y="1255"/>
+        </scene>
+        <!--Storyboard Collection-->
+        <scene sceneID="V2R-xj-UUu">
+            <objects>
+                <navigationController storyboardIdentifier="Collection" title="Storyboard Collection" automaticallyAdjustsScrollViewInsets="NO" useStoryboardIdentifierAsRestorationIdentifier="YES" id="kuS-CX-iVQ" userLabel="Storyboard Collection" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="v6r-4y-ds3">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="kTz-5R-0P4" kind="relationship" relationship="rootViewController" id="2VZ-aY-cPk"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="VHJ-O4-FwE" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="339" y="1255"/>
         </scene>
     </scenes>
 </document>


### PR DESCRIPTION
Previously `SQKFetchedCollectionViewController` and `SQKFetchedTableViewController` subclassed `UICollectionViewController` and `UITableViewController`. This made them less flexible as other views could not be added to the hierarchy in a Storyboard. Now they extend plain old UIViewController.

This also fixes the issue where `SQKFetchedCollectionViewController` was unusable from a Storyboard, because it could not be correctly configured before initialisation. Now it can use an existing `UICollectionView` which is already set up.

Some properties are now configurable from IB. These are `showsSectionsWhenSearching` and `searchingEnabled`.