### PR TITLE
Core data operation without semaphores

### DIFF
--- a/Classes/shared/SQKCoreDataOperation/SQKCoreDataOperation.h
+++ b/Classes/shared/SQKCoreDataOperation/SQKCoreDataOperation.h
@@ -46,10 +46,13 @@
  *  You must call this method when you want save the private context and your work is done.
  *  Saves the (private) managed object context, merges the changes into main context, and finishes
  *  operation.
- *
- *  @param managedObjectContext The managed object context save to and merge.
  */
-- (void)completeOperationBySavingContext:(NSManagedObjectContext *)managedObjectContext;
+- (void)completeAndSave;
+
+/**
+ *  Deprecated. Use completeAndSave instead.
+ */
+- (void)completeOperationBySavingContext:(NSManagedObjectContext *)managedObjectContext DEPRECATED_MSG_ATTRIBUTE("Use completeAndSave instead");
 
 /**
  *  Called from the `start` method when the operation is being executed. You must override this

--- a/Classes/shared/SQKCoreDataOperation/SQKCoreDataOperation.m
+++ b/Classes/shared/SQKCoreDataOperation/SQKCoreDataOperation.m
@@ -100,7 +100,7 @@
 
 #pragma mark - Completion
 
-- (void)completeOperationBySavingContext:(NSManagedObjectContext *)managedObjectContext
+- (void)completeAndSave
 {
     if ([self isCancelled])
     {
@@ -123,6 +123,9 @@
     }
 }
 
+- (void)completeOperationBySavingContext:(NSManagedObjectContext *)managedObjectContext
+{
+    [self completeAndSave];
 }
 
 - (void)finishOperation

--- a/Classes/shared/SQKCoreDataOperation/SQKCoreDataOperation.m
+++ b/Classes/shared/SQKCoreDataOperation/SQKCoreDataOperation.m
@@ -80,7 +80,7 @@
 
 - (BOOL)isConcurrent
 {
-    return YES;
+    return [self isAsynchronous];
 }
 
 - (BOOL)isAsynchronous


### PR DESCRIPTION
Removes use of semaphores which attempted to ensure an operation was completed on the same thread it was executing in.  This has been removed as occasionally the semaphore was not signalled properly, and after some investigation nothing bad seems to happen from completing the operation on the main thread.

This is an alternative to @CaptainRedmuff's fix in pr #83 for issue #84. The benefit of the approach taken here is that the operation is still responsible for merging the contexts, and therefore can ensure it is only completed once the merge has finished. In #83 the operation completes and lets the context manger handle the merge, which could result in the changes not being merged into the context before another operation starts that is dependent on them being there.